### PR TITLE
feat: bilateral leg symmetry score and muscle deficit alerts (#22)

### DIFF
--- a/smart-sleeve-app/__test__/dashboard/DashboardComponents.test.tsx
+++ b/smart-sleeve-app/__test__/dashboard/DashboardComponents.test.tsx
@@ -4,6 +4,7 @@ import { SegmentedControl } from "@/components/dashboard/SegmentedControl";
 import { CircularDataCard } from "@/components/dashboard/CircularDataCard";
 import { CALIBRATION_CHANNEL_LABELS } from "@/components/dashboard/CalibrationOverlay";
 import { getGraphValue, getRawGraphMax } from "@/components/dashboard/RMSGraph";
+import SymmetryCard from "@/components/dashboard/SymmetryCard";
 import {
   RAW_SIGNAL_BADGE_LABEL,
   RAW_SIGNAL_TOGGLE_LABEL,
@@ -81,5 +82,15 @@ describe("Dashboard Components", () => {
   it("uses dynamic raw graph scaling instead of a fixed mock-only ceiling", () => {
     expect(getRawGraphMax([0.02, 0.05, 0.08])).toBeCloseTo(0.1, 5);
     expect(getRawGraphMax([0.5, 1.5, 2])).toBeCloseTo(2.4, 5);
+  });
+
+  it("renders the muscle activation card with single-leg wording", () => {
+    const { getByText, queryByText } = render(
+      <SymmetryCard normalizedPct={[96, 84, 76, 65]} />,
+    );
+
+    expect(getByText("Muscle Activation")).toBeTruthy();
+    expect(getByText("Single-Leg Insights")).toBeTruthy();
+    expect(queryByText("Symmetry Score")).toBeNull();
   });
 });

--- a/smart-sleeve-app/__test__/dashboard/DashboardComponents.test.tsx
+++ b/smart-sleeve-app/__test__/dashboard/DashboardComponents.test.tsx
@@ -137,7 +137,7 @@ describe("Dashboard Components", () => {
     );
 
     expect(getByText("Symmetry Score")).toBeTruthy();
-    expect(getByText("Bilateral Comparison")).toBeTruthy();
+    expect(getByText("Quadriceps Sets · Bilateral Analysis")).toBeTruthy();
     expect(queryByText("Single-Leg Insights")).toBeNull();
   });
 });

--- a/smart-sleeve-app/__test__/dashboard/DashboardComponents.test.tsx
+++ b/smart-sleeve-app/__test__/dashboard/DashboardComponents.test.tsx
@@ -10,6 +10,7 @@ import {
   RAW_SIGNAL_TOGGLE_LABEL,
 } from "../../components/dashboard/signalDisplay";
 import StatCard from "@/components/StatCard";
+import type { BilateralComparisonResult } from "@/services/SymmetryService";
 
 jest.mock("expo-haptics", () => ({
   impactAsync: jest.fn(),
@@ -85,12 +86,58 @@ describe("Dashboard Components", () => {
   });
 
   it("renders the muscle activation card with single-leg wording", () => {
+    const comparison: BilateralComparisonResult = {
+      symmetryScore: 82,
+      exerciseType: "quad-sets",
+      healthySide: "RIGHT",
+      injuredSide: "LEFT",
+      healthySessionId: "healthy-1",
+      injuredSessionId: "injured-1",
+      vmoVlBalance: 11,
+      hamstringGuarding: 6,
+      hasAnyWarning: false,
+      channels: [
+        {
+          channelIndex: 0,
+          label: "VMO",
+          healthyPct: 88,
+          injuredPct: 74,
+          deficit: 14,
+          hasWarning: false,
+        },
+        {
+          channelIndex: 1,
+          label: "VL",
+          healthyPct: 84,
+          injuredPct: 73,
+          deficit: 11,
+          hasWarning: false,
+        },
+        {
+          channelIndex: 2,
+          label: "ST",
+          healthyPct: 69,
+          injuredPct: 55,
+          deficit: 14,
+          hasWarning: false,
+        },
+        {
+          channelIndex: 3,
+          label: "BF",
+          healthyPct: 42,
+          injuredPct: 48,
+          deficit: 0,
+          hasWarning: false,
+        },
+      ],
+    };
+
     const { getByText, queryByText } = render(
-      <SymmetryCard normalizedPct={[96, 84, 76, 65]} />,
+      <SymmetryCard comparison={comparison} />,
     );
 
-    expect(getByText("Muscle Activation")).toBeTruthy();
-    expect(getByText("Single-Leg Insights")).toBeTruthy();
-    expect(queryByText("Symmetry Score")).toBeNull();
+    expect(getByText("Symmetry Score")).toBeTruthy();
+    expect(getByText("Bilateral Comparison")).toBeTruthy();
+    expect(queryByText("Single-Leg Insights")).toBeNull();
   });
 });

--- a/smart-sleeve-app/__test__/services/Database.test.ts
+++ b/smart-sleeve-app/__test__/services/Database.test.ts
@@ -50,6 +50,9 @@ describe("Database service", () => {
     expect(mockDb.execAsync).toHaveBeenCalledWith(
       "ALTER TABLE sessions ADD COLUMN intensity_score REAL NOT NULL DEFAULT 0",
     );
+    expect(mockDb.execAsync).toHaveBeenCalledWith(
+      "ALTER TABLE sessions ADD COLUMN normalized_channel_means TEXT NOT NULL DEFAULT '[]'",
+    );
   });
 
   test("fetchSessionsByFilters builds a filtered user-scoped query", async () => {
@@ -98,14 +101,15 @@ describe("Database service", () => {
         exerciseQuality: 0.8,
         completionRate: 80,
         intensityScore: 6,
+        normalizedChannelMeans: [75, 70, 65, 60],
       },
     });
 
     const [sql, values] = mockDb.runAsync.mock.calls[0];
     const placeholderCount = (sql.match(/\?/g) ?? []).length;
 
-    expect(placeholderCount).toBe(19);
-    expect(values).toHaveLength(19);
+    expect(placeholderCount).toBe(20);
+    expect(values).toHaveLength(20);
   });
 
   test("bulkInsertEMGSamples batches many EMG rows into a single multi-value insert", async () => {
@@ -172,6 +176,7 @@ describe("Database service", () => {
       exercise_quality: 0.8,
       completion_rate: 80,
       intensity_score: 6,
+      normalized_channel_means: "[75,70,65,60]",
       synced: 0,
     });
 
@@ -195,6 +200,7 @@ describe("Database service", () => {
         analytics: expect.objectContaining({
           completionRate: 80,
           intensityScore: 6,
+          normalizedChannelMeans: [75, 70, 65, 60],
         }),
       }),
     );

--- a/smart-sleeve-app/__test__/services/SessionService.test.ts
+++ b/smart-sleeve-app/__test__/services/SessionService.test.ts
@@ -221,6 +221,7 @@ describe("SessionService", () => {
       expect.objectContaining({
         analytics: expect.objectContaining({
           deficitPercentage: 0,
+          normalizedChannelMeans: [75, 75, 15, 20],
         }),
       }),
       mockDb,

--- a/smart-sleeve-app/__test__/services/SymmetryService.test.ts
+++ b/smart-sleeve-app/__test__/services/SymmetryService.test.ts
@@ -1,38 +1,130 @@
 import {
-  computeActivationInsights,
+  buildBilateralComparison,
+  findLatestBilateralComparison,
   WARNING_THRESHOLD,
 } from "@/services/SymmetryService";
+import type { Session, SessionAnalytics } from "@/services/Database";
 
 describe("SymmetryService", () => {
-  it("computes a single-leg activation score from normalized % MVC data", () => {
-    const result = computeActivationInsights([95, 72, 110, 63]);
+  const defaultAnalytics: SessionAnalytics = {
+    avgActivation: 0.4,
+    maxActivation: 0.8,
+    deficitPercentage: 10,
+    fatigueScore: 4,
+    romDegrees: 90,
+    exerciseQuality: 0.8,
+    completionRate: 80,
+    intensityScore: 7,
+    normalizedChannelMeans: [80, 78, 65, 42],
+  };
+  const buildAnalytics = (
+    overrides: Partial<SessionAnalytics> = {},
+  ): SessionAnalytics => ({
+    ...defaultAnalytics,
+    ...overrides,
+  });
 
-    expect(result.activationScore).toBe(83);
-    expect(result.channels.map((channel) => channel.normalizedPct)).toEqual([
-      95, 72, 110, 63,
+  const createSession = (
+    overrides: Omit<Partial<Session>, "analytics"> & {
+      analytics?: Partial<SessionAnalytics>;
+    } = {},
+  ): Session => {
+    const { analytics, ...sessionOverrides } = overrides;
+
+    return {
+      id: "session-default",
+      userId: "athlete@example.com",
+      exerciseType: "quad-sets",
+      side: "LEFT",
+      timestamp: 1000,
+      duration: 60,
+      avgFlexion: 90,
+      exerciseIds: ["quad-sets"],
+      synced: false,
+      ...sessionOverrides,
+      analytics: buildAnalytics(analytics),
+    };
+  };
+
+  it("computes the true healthy-vs-injured channel deficits", () => {
+    const result = buildBilateralComparison(
+      createSession({
+        id: "healthy",
+        side: "RIGHT",
+        analytics: { normalizedChannelMeans: [88, 84, 70, 40] },
+      }),
+      createSession({
+        id: "injured",
+        side: "LEFT",
+        analytics: { normalizedChannelMeans: [72, 68, 52, 54] },
+      }),
+    );
+
+    expect(result.symmetryScore).toBe(88);
+    expect(result.channels.map((channel) => channel.deficit)).toEqual([
+      16, 16, 18, 0,
     ]);
   });
 
-  it("flags channels whose target gap exceeds the warning threshold", () => {
-    const result = computeActivationInsights([100, 68, 71, 40]);
+  it("flags muscle groups whose bilateral deficit exceeds the warning threshold", () => {
+    const result = buildBilateralComparison(
+      createSession({
+        id: "healthy",
+        side: "RIGHT",
+        analytics: { normalizedChannelMeans: [100, 92, 88, 48] },
+      }),
+      createSession({
+        id: "injured",
+        side: "LEFT",
+        analytics: { normalizedChannelMeans: [62, 55, 58, 66] },
+      }),
+    );
 
     expect(WARNING_THRESHOLD).toBe(30);
-    expect(result.channels.map((channel) => channel.targetGap)).toEqual([
-      0, 32, 29, 60,
+    expect(result.channels.map((channel) => channel.deficit)).toEqual([
+      38, 37, 30, 0,
     ]);
     expect(result.channels.map((channel) => channel.hasWarning)).toEqual([
-      false,
+      true,
       true,
       false,
-      true,
+      false,
     ]);
     expect(result.hasAnyWarning).toBe(true);
   });
 
-  it("surfaces quad balance and hamstring load from the same-leg channels", () => {
-    const result = computeActivationInsights([88, 61, 52, 84]);
+  it("finds the latest comparable healthy/injured pair for the same exercise", () => {
+    const result = findLatestBilateralComparison(
+      [
+        createSession({
+          id: "old-healthy",
+          side: "RIGHT",
+          timestamp: 1000,
+          analytics: { normalizedChannelMeans: [78, 74, 60, 39] },
+        }),
+        createSession({
+          id: "latest-healthy",
+          side: "RIGHT",
+          timestamp: 3000,
+          analytics: { normalizedChannelMeans: [88, 84, 72, 41] },
+        }),
+        createSession({
+          id: "latest-injured",
+          side: "LEFT",
+          timestamp: 4000,
+          analytics: { normalizedChannelMeans: [70, 64, 55, 49] },
+        }),
+      ],
+      "LEFT",
+    );
 
-    expect(result.vmoVlBalance).toBe(27);
-    expect(result.hamstringGuarding).toBe(84);
+    expect(result).toEqual(
+      expect.objectContaining({
+        healthySessionId: "latest-healthy",
+        injuredSessionId: "latest-injured",
+        vmoVlBalance: 6,
+        hamstringGuarding: 8,
+      }),
+    );
   });
 });

--- a/smart-sleeve-app/__test__/services/SymmetryService.test.ts
+++ b/smart-sleeve-app/__test__/services/SymmetryService.test.ts
@@ -1,0 +1,38 @@
+import {
+  computeActivationInsights,
+  WARNING_THRESHOLD,
+} from "@/services/SymmetryService";
+
+describe("SymmetryService", () => {
+  it("computes a single-leg activation score from normalized % MVC data", () => {
+    const result = computeActivationInsights([95, 72, 110, 63]);
+
+    expect(result.activationScore).toBe(83);
+    expect(result.channels.map((channel) => channel.normalizedPct)).toEqual([
+      95, 72, 110, 63,
+    ]);
+  });
+
+  it("flags channels whose target gap exceeds the warning threshold", () => {
+    const result = computeActivationInsights([100, 68, 71, 40]);
+
+    expect(WARNING_THRESHOLD).toBe(30);
+    expect(result.channels.map((channel) => channel.targetGap)).toEqual([
+      0, 32, 29, 60,
+    ]);
+    expect(result.channels.map((channel) => channel.hasWarning)).toEqual([
+      false,
+      true,
+      false,
+      true,
+    ]);
+    expect(result.hasAnyWarning).toBe(true);
+  });
+
+  it("surfaces quad balance and hamstring load from the same-leg channels", () => {
+    const result = computeActivationInsights([88, 61, 52, 84]);
+
+    expect(result.vmoVlBalance).toBe(27);
+    expect(result.hamstringGuarding).toBe(84);
+  });
+});

--- a/smart-sleeve-app/__test__/store/migrations.test.ts
+++ b/smart-sleeve-app/__test__/store/migrations.test.ts
@@ -35,4 +35,21 @@ describe("store migrations", () => {
 
     expect(migrated.user.profileOwnerEmail).toBe("athlete@example.com");
   });
+
+  it("moves the legacy single calibration onto the injured side during v6 migration", () => {
+    const migrated = migrations[6]({
+      user: {
+        injuredSide: "RIGHT",
+        calibration: {
+          baseline: [0.1, 0.2, 0.3, 0.4],
+          mvc: [1.1, 1.2, 1.3, 1.4],
+          calibratedAt: 123,
+        },
+      },
+    });
+
+    expect(migrated.user.measurementSide).toBe("RIGHT");
+    expect(migrated.user.calibrationsBySide.RIGHT.calibratedAt).toBe(123);
+    expect(migrated.user.calibrationsBySide.LEFT.calibratedAt).toBeNull();
+  });
 });

--- a/smart-sleeve-app/__test__/store/migrations.test.ts
+++ b/smart-sleeve-app/__test__/store/migrations.test.ts
@@ -1,15 +1,27 @@
 import { migrations } from "@/store/migrations";
 
 describe("store migrations", () => {
-  it("does not force legacy installs back through onboarding during v3 migration", () => {
+  it("routes legacy installs without an injured side back through onboarding during v3 migration", () => {
     const migrated = migrations[3]({
       user: {
         email: "existing@example.com",
       },
     });
 
-    expect(migrated.user.hasCompletedOnboarding).toBe(true);
+    expect(migrated.user.hasCompletedOnboarding).toBe(false);
     expect(migrated.user.injuredSide).toBeNull();
+  });
+
+  it("keeps legacy onboarding complete when an injured side already exists", () => {
+    const migrated = migrations[3]({
+      user: {
+        email: "existing@example.com",
+        injuredSide: "RIGHT",
+      },
+    });
+
+    expect(migrated.user.hasCompletedOnboarding).toBe(true);
+    expect(migrated.user.injuredSide).toBe("RIGHT");
   });
 
   it("preserves explicit onboarding flags when migrating v3 state", () => {

--- a/smart-sleeve-app/__test__/store/userSlice.test.ts
+++ b/smart-sleeve-app/__test__/store/userSlice.test.ts
@@ -5,6 +5,7 @@ import reducer, {
   setCalibration,
   setInjuredSide,
   setInjuryDetails,
+  setMeasurementSide,
   setTherapyGoal,
   toggleNormalizedMode,
   type CalibrationCoefficients,
@@ -62,7 +63,27 @@ describe("userSlice onboarding ownership", () => {
     expect(nextState.injuryDetails).toBeNull();
     expect(nextState.therapyGoal).toBeNull();
     expect(nextState.showNormalized).toBe(false);
-    expect(nextState.calibration.calibratedAt).toBeNull();
+    expect(nextState.calibrationsBySide.RIGHT.calibratedAt).toBeNull();
     expect(nextState.profileOwnerEmail).toBe("new-athlete@example.com");
+  });
+
+  it("stores calibration separately for each measured side", () => {
+    let state = reducer(
+      undefined,
+      login({ email: "athlete@example.com", isAuthenticated: true }),
+    );
+    state = reducer(state, setInjuredSide("LEFT"));
+    state = reducer(state, setCalibration(calibratedState));
+    state = reducer(state, setMeasurementSide("RIGHT"));
+    state = reducer(
+      state,
+      setCalibration({
+        ...calibratedState,
+        calibratedAt: 999999,
+      }),
+    );
+
+    expect(state.calibrationsBySide.LEFT.calibratedAt).toBe(123456);
+    expect(state.calibrationsBySide.RIGHT.calibratedAt).toBe(999999);
   });
 });

--- a/smart-sleeve-app/app/(tabs)/dashboard.tsx
+++ b/smart-sleeve-app/app/(tabs)/dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   StyleSheet,
   ScrollView,
@@ -15,15 +15,25 @@ import {
   selectIsWorkoutActive,
   selectWorkout,
 } from "../../store/deviceSlice";
+import { fetchSessionsByFilters } from "@/services/Database";
+import {
+  findLatestBilateralComparison,
+  type BilateralComparisonResult,
+} from "@/services/SymmetryService";
 import {
   selectIsCalibrated,
   selectShowNormalized,
   toggleNormalizedMode,
   setCalibration,
   selectInjuredSide,
+  selectMeasurementSide,
+  setMeasurementSide,
 } from "../../store/userSlice";
-import type { CalibrationCoefficients } from "../../store/userSlice";
-import { RootState } from "../../store/store";
+import type {
+  CalibrationCoefficients,
+  InjuredSide,
+} from "../../store/userSlice";
+import type { RootState } from "../../store/store";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { Colors, Shadows } from "@/constants/theme";
 import { IconSymbol } from "@/components/ui/icon-symbol";
@@ -76,15 +86,15 @@ export default function DashboardScreen() {
   const workout = useSelector(selectWorkout);
   const isCalibrated = useSelector(selectIsCalibrated);
   const showNormalized = useSelector(selectShowNormalized);
-  const latestFeatures = useSelector(
-    (state: RootState) => state.device.latestFeatures,
-  );
   const latestCalibrationSample = useSelector(
     (state: RootState) => state.device.latestCalibrationSample,
   );
   const injuredSide = useSelector(selectInjuredSide);
+  const measurementSide = useSelector(selectMeasurementSide);
 
   const [showCalibration, setShowCalibration] = useState(false);
+  const [comparison, setComparison] =
+    useState<BilateralComparisonResult | null>(null);
 
   const currentKneeAngle =
     kneeAngleBuffer.length > 0
@@ -97,6 +107,55 @@ export default function DashboardScreen() {
 
   const userName = user?.email ? user.email.split("@")[0] : "Athlete";
   const channels = getChannels(theme);
+  const healthySide = injuredSide === "LEFT" ? "RIGHT" : "LEFT";
+  const measurementOptions: { label: string; side: InjuredSide }[] = injuredSide
+    ? [
+        {
+          label: injuredSide === "LEFT" ? "Injured Left" : "Injured Right",
+          side: injuredSide,
+        },
+        {
+          label: healthySide === "LEFT" ? "Healthy Left" : "Healthy Right",
+          side: healthySide,
+        },
+      ]
+    : [
+        { label: "Left Leg", side: "LEFT" as const },
+        { label: "Right Leg", side: "RIGHT" as const },
+      ];
+  const selectedMeasurementLabel =
+    measurementOptions.find((option) => option.side === measurementSide)
+      ?.label ?? "Left Leg";
+
+  useEffect(() => {
+    let isActive = true;
+
+    async function loadComparison() {
+      if (!injuredSide) {
+        if (isActive) setComparison(null);
+        return;
+      }
+
+      try {
+        const sessions = await fetchSessionsByFilters({
+          userId: user.email ?? "guest_user",
+        });
+
+        if (!isActive) return;
+        setComparison(findLatestBilateralComparison(sessions, injuredSide));
+      } catch (error) {
+        if (!isActive) return;
+        console.error("Failed to load bilateral comparison", error);
+        setComparison(null);
+      }
+    }
+
+    void loadComparison();
+
+    return () => {
+      isActive = false;
+    };
+  }, [injuredSide, isWorkoutActive, user.email]);
 
   const handleCalibrationComplete = (coeffs: CalibrationCoefficients) => {
     dispatch(setCalibration(coeffs));
@@ -105,6 +164,14 @@ export default function DashboardScreen() {
 
   const handleToggleNormalized = () => {
     dispatch(toggleNormalizedMode());
+  };
+
+  const handleMeasurementSideChange = (optionLabel: string) => {
+    const option = measurementOptions.find(
+      (item) => item.label === optionLabel,
+    );
+    if (!option) return;
+    dispatch(setMeasurementSide(option.side));
   };
 
   const sortedChannels = React.useMemo(() => {
@@ -123,7 +190,6 @@ export default function DashboardScreen() {
   }, [isWorkoutActive, workout.exerciseId, channels]);
 
   const liveCalibrationSample = latestCalibrationSample ?? [];
-  const normalizedRms = latestFeatures?.rmsNormalized ?? null;
 
   return (
     <SafeAreaView
@@ -164,6 +230,22 @@ export default function DashboardScreen() {
           </View>
         )}
 
+        {!isWorkoutActive && (
+          <View style={styles.measurementSection}>
+            <ThemedText
+              type="label"
+              style={[styles.sectionTitle, { color: theme.textSecondary }]}
+            >
+              Measuring Today
+            </ThemedText>
+            <SegmentedControl
+              options={measurementOptions.map((option) => option.label)}
+              selectedOption={selectedMeasurementLabel}
+              onSelect={handleMeasurementSideChange}
+            />
+          </View>
+        )}
+
         <View style={styles.calibrationRow}>
           <TouchableOpacity
             style={[
@@ -179,7 +261,9 @@ export default function DashboardScreen() {
             <ThemedText
               style={[styles.calibrateBtnText, { color: theme.primary }]}
             >
-              {isCalibrated ? "Calibrated" : "Calibrate Sensors"}
+              {isCalibrated
+                ? `Recalibrate ${selectedMeasurementLabel}`
+                : `Calibrate ${selectedMeasurementLabel}`}
             </ThemedText>
           </TouchableOpacity>
 
@@ -276,8 +360,28 @@ export default function DashboardScreen() {
           })}
         </View>
 
-        {isCalibrated && showNormalized && normalizedRms && (
-          <SymmetryCard normalizedPct={normalizedRms} />
+        {!isWorkoutActive && comparison && (
+          <SymmetryCard comparison={comparison} />
+        )}
+
+        {!isWorkoutActive && injuredSide && !comparison && (
+          <View
+            style={[
+              styles.comparisonHintCard,
+              {
+                backgroundColor: theme.secondaryCard,
+                borderColor: theme.border,
+              },
+            ]}
+          >
+            <ThemedText type="bodyBold" style={{ color: theme.text }}>
+              Bilateral comparison unlocks after both legs are recorded.
+            </ThemedText>
+            <ThemedText style={{ color: theme.textSecondary }}>
+              Complete one calibrated session on the healthy leg and one on the
+              injured leg for the same exercise.
+            </ThemedText>
+          </View>
         )}
 
         {!isWorkoutActive && (
@@ -319,6 +423,7 @@ const styles = StyleSheet.create({
     gap: 12,
     marginBottom: 24,
   },
+  measurementSection: { gap: 12, marginBottom: 20 },
   calibrateBtn: {
     flex: 1,
     flexDirection: "row",
@@ -347,6 +452,13 @@ const styles = StyleSheet.create({
   sectionTitle: { fontSize: 12, fontWeight: "700", letterSpacing: 1 },
   pill: { paddingHorizontal: 8, paddingVertical: 4, borderRadius: 6 },
   unitLabel: { fontSize: 9, fontWeight: "800", color: "#64748B" },
+  comparisonHintCard: {
+    borderWidth: 1,
+    borderRadius: 20,
+    padding: 18,
+    gap: 8,
+    marginBottom: 16,
+  },
   gridContainer: { gap: 16, marginTop: 12 },
   gridRow: {
     flexDirection: "row",

--- a/smart-sleeve-app/app/(tabs)/dashboard.tsx
+++ b/smart-sleeve-app/app/(tabs)/dashboard.tsx
@@ -39,6 +39,7 @@ import {
   getSignalBadgeLabel,
   getSignalToggleLabel,
 } from "@/components/dashboard/signalDisplay";
+import SymmetryCard from "@/components/dashboard/SymmetryCard";
 
 import { ScreenHeader } from "@/components/ui/ScreenHeader";
 
@@ -82,6 +83,9 @@ export default function DashboardScreen() {
   const workout = useSelector(selectWorkout);
   const isCalibrated = useSelector(selectIsCalibrated);
   const showNormalized = useSelector(selectShowNormalized);
+  const latestFeatures = useSelector(
+    (state: RootState) => state.device.latestFeatures,
+  );
   const latestCalibrationSample = useSelector(
     (state: RootState) => state.device.latestCalibrationSample,
   );
@@ -277,6 +281,10 @@ export default function DashboardScreen() {
             );
           })}
         </View>
+
+        {isCalibrated && showNormalized && (latestFeatures as any)?.rmsNormalized && (
+          <SymmetryCard normalizedPct={latestFeatures.rmsNormalized} />
+        )}
 
         {!isWorkoutActive && (
           <View style={styles.gridContainer}>

--- a/smart-sleeve-app/app/(tabs)/dashboard.tsx
+++ b/smart-sleeve-app/app/(tabs)/dashboard.tsx
@@ -43,33 +43,26 @@ import SymmetryCard from "@/components/dashboard/SymmetryCard";
 
 import { ScreenHeader } from "@/components/ui/ScreenHeader";
 
-const getChannels = (injuredSide: "LEFT" | "RIGHT" | null, theme: any) => {
-  const isLeftInjured = (injuredSide ?? "LEFT") === "LEFT";
-  const injured = (name: string) => `${name} (Injured)`;
-  const healthy = (name: string) => `${name} (Healthy)`;
+const getChannels = (theme: any) => {
   return [
     {
       id: 0,
-      label: isLeftInjured ? injured("VMO") : healthy("VMO"),
+      label: "VMO",
       color: theme.primary,
     },
     {
       id: 1,
-      label: isLeftInjured ? injured("VL") : healthy("VL"),
+      label: "VL",
       color: "#FF6B6B",
     },
     {
       id: 2,
-      label: isLeftInjured
-        ? injured("Semitendinosus")
-        : healthy("Semitendinosus"),
+      label: "Semitendinosus",
       color: "#4ECDC4",
     },
     {
       id: 3,
-      label: isLeftInjured
-        ? injured("Biceps Femoris")
-        : healthy("Biceps Femoris"),
+      label: "Biceps Femoris",
       color: "#FFE66D",
     },
   ];
@@ -103,7 +96,7 @@ export default function DashboardScreen() {
   const [timeframe, setTimeframe] = useState("Daily");
 
   const userName = user?.email ? user.email.split("@")[0] : "Athlete";
-  const channels = getChannels(injuredSide, theme);
+  const channels = getChannels(theme);
 
   const handleCalibrationComplete = (coeffs: CalibrationCoefficients) => {
     dispatch(setCalibration(coeffs));

--- a/smart-sleeve-app/app/(tabs)/dashboard.tsx
+++ b/smart-sleeve-app/app/(tabs)/dashboard.tsx
@@ -130,6 +130,7 @@ export default function DashboardScreen() {
   }, [isWorkoutActive, workout.exerciseId, channels]);
 
   const liveCalibrationSample = latestCalibrationSample ?? [];
+  const normalizedRms = latestFeatures?.rmsNormalized ?? null;
 
   return (
     <SafeAreaView
@@ -282,8 +283,8 @@ export default function DashboardScreen() {
           })}
         </View>
 
-        {isCalibrated && showNormalized && (latestFeatures as any)?.rmsNormalized && (
-          <SymmetryCard normalizedPct={latestFeatures.rmsNormalized} />
+        {isCalibrated && showNormalized && normalizedRms && (
+          <SymmetryCard normalizedPct={normalizedRms} />
         )}
 
         {!isWorkoutActive && (

--- a/smart-sleeve-app/app/(tabs)/dashboard.tsx
+++ b/smart-sleeve-app/app/(tabs)/dashboard.tsx
@@ -103,7 +103,6 @@ export default function DashboardScreen() {
 
   const colorScheme = useColorScheme();
   const theme = Colors[colorScheme ?? "light"];
-  const [timeframe, setTimeframe] = useState("Daily");
 
   const userName = user?.email ? user.email.split("@")[0] : "Athlete";
   const channels = getChannels(theme);
@@ -213,16 +212,10 @@ export default function DashboardScreen() {
               <ThemedText
                 style={[styles.sideLabel, { color: theme.textSecondary }]}
               >
-                REHABBING: {injuredSide === "LEFT" ? "Left" : "Right"} Knee
+                RECOVERY TARGET: {injuredSide === "LEFT" ? "Left" : "Right"}{" "}
+                Knee
               </ThemedText>
             )}
-            <View style={{ marginTop: 24 }}>
-              <SegmentedControl
-                options={["Daily", "Weekly", "Monthly"]}
-                selectedOption={timeframe}
-                onSelect={setTimeframe}
-              />
-            </View>
           </View>
         ) : (
           <View style={styles.workoutHudHeader}>
@@ -302,7 +295,7 @@ export default function DashboardScreen() {
           >
             <View style={styles.actionTextContainer}>
               <ThemedText style={[styles.actionTitle, { color: "#fff" }]}>
-                Start Rehab Session
+                Start Measurement Session
               </ThemedText>
               <ThemedText
                 style={[
@@ -310,7 +303,7 @@ export default function DashboardScreen() {
                   { color: "rgba(255,255,255,0.8)" },
                 ]}
               >
-                Follow clinical exercise library
+                Record the healthy or injured leg with the same protocol
               </ThemedText>
             </View>
             <IconSymbol name="chevron.right" size={24} color="#fff" />
@@ -360,6 +353,17 @@ export default function DashboardScreen() {
           })}
         </View>
 
+        {!isWorkoutActive && injuredSide && (
+          <View style={styles.sectionTitleRow}>
+            <ThemedText
+              type="label"
+              style={[styles.sectionTitle, { color: theme.textSecondary }]}
+            >
+              Healthy vs Injured Comparison
+            </ThemedText>
+          </View>
+        )}
+
         {!isWorkoutActive && comparison && (
           <SymmetryCard comparison={comparison} />
         )}
@@ -375,11 +379,12 @@ export default function DashboardScreen() {
             ]}
           >
             <ThemedText type="bodyBold" style={{ color: theme.text }}>
-              Bilateral comparison unlocks after both legs are recorded.
+              Symmetry Score appears after both legs are recorded.
             </ThemedText>
             <ThemedText style={{ color: theme.textSecondary }}>
               Complete one calibrated session on the healthy leg and one on the
-              injured leg for the same exercise.
+              injured leg for the same exercise. The comparison card will appear
+              here on the Dashboard.
             </ThemedText>
           </View>
         )}

--- a/smart-sleeve-app/app/(tabs)/exercises.tsx
+++ b/smart-sleeve-app/app/(tabs)/exercises.tsx
@@ -7,7 +7,7 @@ import {
   ScrollView,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { router } from "expo-router";
 import { IconSymbol } from "@/components/ui/icon-symbol";
 import { ThemedText } from "@/components/themed-text";
@@ -15,6 +15,11 @@ import { useColorScheme } from "@/hooks/use-color-scheme";
 import { Colors, Shadows } from "@/constants/theme";
 import { EXERCISE_LIBRARY, Exercise } from "@/constants/exercises";
 import { startWorkout } from "@/store/deviceSlice";
+import {
+  selectInjuredSide,
+  selectMeasurementSide,
+  setMeasurementSide,
+} from "@/store/userSlice";
 
 import { ScreenHeader } from "@/components/ui/ScreenHeader";
 import { AppModal } from "@/components/ui/AppModal";
@@ -30,14 +35,19 @@ export default function ExercisesScreen() {
   const colorScheme = useColorScheme() ?? "light";
   const theme = Colors[colorScheme];
   const dispatch = useDispatch();
+  const measurementSide = useSelector(selectMeasurementSide);
+  const injuredSide = useSelector(selectInjuredSide);
 
   const [selectedExercise, setSelectedExercise] = useState<Exercise | null>(
     null,
   );
-  const [selectedSide, setSelectedSide] = useState<"LEFT" | "RIGHT">("LEFT");
+  const [selectedSide, setSelectedSide] = useState<"LEFT" | "RIGHT">(
+    measurementSide,
+  );
 
   const handleStartSession = () => {
     if (!selectedExercise) return;
+    dispatch(setMeasurementSide(selectedSide));
     dispatch(
       startWorkout({
         exerciseId: selectedExercise.id,
@@ -87,7 +97,7 @@ export default function ExercisesScreen() {
                   Shadows.card,
                 ]}
                 onPress={() => {
-                  setSelectedSide("LEFT");
+                  setSelectedSide(measurementSide);
                   setSelectedExercise(exercise);
                 }}
                 activeOpacity={0.9}
@@ -160,7 +170,7 @@ export default function ExercisesScreen() {
                       { backgroundColor: theme.primary, ...Shadows.button },
                     ]}
                     onPress={() => {
-                      setSelectedSide("LEFT");
+                      setSelectedSide(measurementSide);
                       setSelectedExercise(exercise);
                     }}
                   >
@@ -228,7 +238,13 @@ export default function ExercisesScreen() {
                   },
                 ]}
               >
-                {side === "LEFT" ? "Left Knee" : "Right Knee"}
+                {injuredSide === side
+                  ? side === "LEFT"
+                    ? "Injured Left"
+                    : "Injured Right"
+                  : side === "LEFT"
+                    ? "Healthy Left"
+                    : "Healthy Right"}
               </ThemedText>
             </TouchableOpacity>
           ))}

--- a/smart-sleeve-app/app/(tabs)/exercises.tsx
+++ b/smart-sleeve-app/app/(tabs)/exercises.tsx
@@ -82,7 +82,7 @@ export default function ExercisesScreen() {
           Guided Rehab
         </ThemedText>
         <ThemedText style={[styles.subtitle, { color: theme.textSecondary }]}>
-          Choose an exercise to begin your supervised clinical session
+          Choose an exercise to begin a guided measurement session
         </ThemedText>
 
         <View style={styles.listContainer}>
@@ -190,7 +190,7 @@ export default function ExercisesScreen() {
         visible={selectedExercise !== null}
         onClose={() => setSelectedExercise(null)}
         title={selectedExercise?.name}
-        subtitle="Select the limb you are rehabbing today"
+        subtitle="Select the limb you are measuring in this session"
         footer={
           <>
             <TouchableOpacity
@@ -201,7 +201,7 @@ export default function ExercisesScreen() {
               onPress={handleStartSession}
             >
               <ThemedText style={styles.confirmButtonText}>
-                Begin Session
+                Begin Measurement Session
               </ThemedText>
             </TouchableOpacity>
             <TouchableOpacity

--- a/smart-sleeve-app/app/_layout.tsx
+++ b/smart-sleeve-app/app/_layout.tsx
@@ -29,12 +29,13 @@ function AppNavigator({
     (state: RootState) => state.user.hasCompletedOnboarding,
   );
   const isLoggedIn = useSelector((state: RootState) => state.user.isLoggedIn);
+  const injuredSide = useSelector((state: RootState) => state.user.injuredSide);
 
   useEffect(() => {
-    if (isLoggedIn && !hasCompletedOnboarding) {
+    if (isLoggedIn && (!hasCompletedOnboarding || !injuredSide)) {
       router.replace("/onboarding" as any);
     }
-  }, [isLoggedIn, hasCompletedOnboarding]);
+  }, [isLoggedIn, hasCompletedOnboarding, injuredSide]);
 
   return (
     <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>

--- a/smart-sleeve-app/components/dashboard/SymmetryCard.tsx
+++ b/smart-sleeve-app/components/dashboard/SymmetryCard.tsx
@@ -1,72 +1,139 @@
-import React from 'react';
-import { View, StyleSheet } from 'react-native';
-import { useColorScheme } from '@/hooks/use-color-scheme';
-import { Colors } from '@/constants/theme';
-import { ThemedText } from '@/components/themed-text';
-import { computeSymmetry, WARNING_THRESHOLD } from '@/services/SymmetryService';
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { useColorScheme } from "@/hooks/use-color-scheme";
+import { Colors, Shadows, Typography } from "@/constants/theme";
+import { ThemedText } from "@/components/themed-text";
+import {
+  computeActivationInsights,
+  WARNING_THRESHOLD,
+} from "@/services/SymmetryService";
 
 interface SymmetryCardProps {
   normalizedPct: number[];
 }
 
 export default function SymmetryCard({ normalizedPct }: SymmetryCardProps) {
-  const colorScheme = useColorScheme() ?? 'light';
+  const colorScheme = useColorScheme() ?? "light";
   const theme = Colors[colorScheme];
 
   if (!normalizedPct || normalizedPct.length < 4) return null;
 
-  const result = computeSymmetry(normalizedPct);
+  const result = computeActivationInsights(normalizedPct);
 
-  const scoreColor = result.symmetryScore >= 80
-    ? theme.success
-    : result.symmetryScore >= 60
-    ? theme.warning
-    : '#E63946';
+  const scoreColor =
+    result.activationScore >= 80
+      ? theme.success
+      : result.activationScore >= 60
+        ? theme.warning
+        : theme.text;
 
   return (
     <View style={[styles.card, { backgroundColor: theme.cardBackground }]}>
-      {/* Header */}
       <View style={styles.header}>
-        <ThemedText style={[styles.title, { color: theme.text }]}>Symmetry Score</ThemedText>
+        <View style={styles.headerCopy}>
+          <ThemedText style={[styles.eyebrow, { color: theme.textSecondary }]}>
+            Single-Leg Insights
+          </ThemedText>
+          <ThemedText style={[styles.title, { color: theme.text }]}>
+            Muscle Activation
+          </ThemedText>
+        </View>
         {result.hasAnyWarning && (
-          <View style={[styles.alertBadge, { backgroundColor: '#E6394620' }]}>
-            <ThemedText style={styles.alertText}>⚠️ Deficit &gt;{WARNING_THRESHOLD}%</ThemedText>
+          <View
+            style={[
+              styles.alertBadge,
+              {
+                backgroundColor: theme.warning + "15",
+                borderColor: theme.warning,
+              },
+            ]}
+          >
+            <ThemedText style={[styles.alertText, { color: theme.warning }]}>
+              Gap &gt; {WARNING_THRESHOLD}%
+            </ThemedText>
           </View>
         )}
       </View>
 
-      {/* Score Circle */}
+      <ThemedText style={[styles.subtitle, { color: theme.textSecondary }]}>
+        Live % MVC snapshot for the instrumented leg. Use this to spot uneven
+        quad loading and hamstring over-activity.
+      </ThemedText>
+
       <View style={styles.scoreRow}>
-        <View style={[styles.scoreCircle, { borderColor: scoreColor }]}>
-          <ThemedText style={[styles.scoreValue, { color: scoreColor }]}>
-            {result.symmetryScore}
+        <View
+          style={[
+            styles.scoreCircle,
+            { borderColor: scoreColor, backgroundColor: theme.secondaryCard },
+          ]}
+        >
+          <ThemedText
+            style={[styles.scoreLabel, { color: theme.textSecondary }]}
+          >
+            Activation
           </ThemedText>
-          <ThemedText style={[styles.scoreUnit, { color: theme.textSecondary }]}>/ 100</ThemedText>
+          <ThemedText style={[styles.scoreValue, { color: scoreColor }]}>
+            {result.activationScore}
+          </ThemedText>
+          <ThemedText
+            style={[styles.scoreUnit, { color: theme.textSecondary }]}
+          >
+            out of 100
+          </ThemedText>
         </View>
 
         <View style={styles.insightsCol}>
-          <View style={[styles.insightRow, { backgroundColor: theme.background }]}>
-            <ThemedText style={[styles.insightLabel, { color: theme.textSecondary }]}>VMO vs VL Balance</ThemedText>
-            <ThemedText style={[
-              styles.insightValue,
-              { color: result.vmoVlBalance > WARNING_THRESHOLD ? '#E63946' : theme.success }
-            ]}>
+          <View
+            style={[
+              styles.insightRow,
+              { backgroundColor: theme.secondaryCard },
+            ]}
+          >
+            <ThemedText
+              style={[styles.insightLabel, { color: theme.textSecondary }]}
+            >
+              Quad Balance
+            </ThemedText>
+            <ThemedText
+              style={[
+                styles.insightValue,
+                {
+                  color:
+                    result.vmoVlBalance > WARNING_THRESHOLD
+                      ? theme.warning
+                      : theme.text,
+                },
+              ]}
+            >
               {result.vmoVlBalance}% gap
             </ThemedText>
           </View>
-          <View style={[styles.insightRow, { backgroundColor: theme.background }]}>
-            <ThemedText style={[styles.insightLabel, { color: theme.textSecondary }]}>Hamstring Guarding</ThemedText>
-            <ThemedText style={[
-              styles.insightValue,
-              { color: result.hamstringGuarding > 80 ? '#E63946' : theme.success }
-            ]}>
+          <View
+            style={[
+              styles.insightRow,
+              { backgroundColor: theme.secondaryCard },
+            ]}
+          >
+            <ThemedText
+              style={[styles.insightLabel, { color: theme.textSecondary }]}
+            >
+              Hamstring Load
+            </ThemedText>
+            <ThemedText
+              style={[
+                styles.insightValue,
+                {
+                  color:
+                    result.hamstringGuarding > 80 ? theme.warning : theme.text,
+                },
+              ]}
+            >
               BF: {result.hamstringGuarding}%
             </ThemedText>
           </View>
         </View>
       </View>
 
-      {/* Per-channel breakdown */}
       <View style={styles.channelGrid}>
         {result.channels.map((ch) => (
           <View
@@ -74,25 +141,26 @@ export default function SymmetryCard({ normalizedPct }: SymmetryCardProps) {
             style={[
               styles.channelChip,
               {
-                backgroundColor: ch.hasWarning ? '#E6394615' : theme.background,
-                borderColor: ch.hasWarning ? '#E63946' : theme.border,
-              }
+                backgroundColor: theme.secondaryCard,
+                borderColor: ch.hasWarning ? theme.warning : theme.border,
+              },
             ]}
           >
-            <ThemedText style={[styles.channelLabel, { color: theme.textSecondary }]}>
+            <ThemedText
+              style={[styles.channelLabel, { color: theme.textSecondary }]}
+            >
               {ch.label}
             </ThemedText>
-            <ThemedText style={[
-              styles.channelPct,
-              { color: ch.hasWarning ? '#E63946' : theme.text }
-            ]}>
+            <ThemedText style={[styles.channelPct, { color: theme.text }]}>
               {ch.normalizedPct}%
             </ThemedText>
-            <ThemedText style={[
-              styles.channelDeficit,
-              { color: ch.hasWarning ? '#E63946' : theme.textSecondary }
-            ]}>
-              {ch.hasWarning ? `⚠️ -${ch.deficit}%` : `✓ -${ch.deficit}%`}
+            <ThemedText
+              style={[
+                styles.channelDeficit,
+                { color: ch.hasWarning ? theme.warning : theme.textSecondary },
+              ]}
+            >
+              {ch.hasWarning ? `Target gap ${ch.targetGap}%` : "On target"}
             </ThemedText>
           </View>
         ))}
@@ -103,49 +171,69 @@ export default function SymmetryCard({ normalizedPct }: SymmetryCardProps) {
 
 const styles = StyleSheet.create({
   card: {
-    borderRadius: 20,
+    borderRadius: 24,
     padding: 20,
     marginBottom: 16,
     gap: 16,
+    ...Shadows.card,
   },
   header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
+    flexDirection: "row",
+    gap: 12,
+    alignItems: "center",
+    justifyContent: "space-between",
   },
-  title: { fontSize: 16, fontWeight: '700' },
+  headerCopy: { flex: 1, gap: 2 },
+  eyebrow: { ...Typography.label },
+  title: { ...Typography.heading3 },
+  subtitle: { ...Typography.caption },
   alertBadge: {
-    paddingHorizontal: 10, paddingVertical: 4,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
     borderRadius: 12,
+    borderWidth: 1,
   },
-  alertText: { fontSize: 12, color: '#E63946', fontWeight: '600' },
+  alertText: { fontSize: 12, fontWeight: "600" },
   scoreRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     gap: 16,
   },
   scoreCircle: {
-    width: 90, height: 90, borderRadius: 45,
-    borderWidth: 4,
-    alignItems: 'center', justifyContent: 'center',
+    width: 112,
+    height: 112,
+    borderRadius: 56,
+    borderWidth: 3,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 12,
   },
-  scoreValue: { fontSize: 28, fontWeight: '800' },
-  scoreUnit: { fontSize: 11 },
+  scoreLabel: { ...Typography.label },
+  scoreValue: { fontSize: 30, fontWeight: "800" },
+  scoreUnit: { fontSize: 11, textAlign: "center" },
   insightsCol: { flex: 1, gap: 8 },
   insightRow: {
-    flexDirection: 'row', justifyContent: 'space-between',
-    alignItems: 'center', padding: 10, borderRadius: 10,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    padding: 10,
+    borderRadius: 10,
   },
   insightLabel: { fontSize: 12, flex: 1 },
-  insightValue: { fontSize: 12, fontWeight: '700' },
+  insightValue: { fontSize: 12, fontWeight: "700" },
   channelGrid: {
-    flexDirection: 'row', flexWrap: 'wrap', gap: 8,
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
   },
   channelChip: {
-    width: '47%', borderWidth: 1, borderRadius: 12,
-    padding: 12, gap: 4,
+    width: "47%",
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 12,
+    gap: 4,
   },
-  channelLabel: { fontSize: 11, fontWeight: '600' },
-  channelPct: { fontSize: 20, fontWeight: '800' },
+  channelLabel: { fontSize: 11, fontWeight: "600" },
+  channelPct: { fontSize: 20, fontWeight: "800" },
   channelDeficit: { fontSize: 11 },
 });

--- a/smart-sleeve-app/components/dashboard/SymmetryCard.tsx
+++ b/smart-sleeve-app/components/dashboard/SymmetryCard.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import { Colors } from '@/constants/theme';
+import { ThemedText } from '@/components/themed-text';
+import { computeSymmetry, WARNING_THRESHOLD } from '@/services/SymmetryService';
+
+interface SymmetryCardProps {
+  normalizedPct: number[];
+}
+
+export default function SymmetryCard({ normalizedPct }: SymmetryCardProps) {
+  const colorScheme = useColorScheme() ?? 'light';
+  const theme = Colors[colorScheme];
+
+  if (!normalizedPct || normalizedPct.length < 4) return null;
+
+  const result = computeSymmetry(normalizedPct);
+
+  const scoreColor = result.symmetryScore >= 80
+    ? theme.success
+    : result.symmetryScore >= 60
+    ? theme.warning
+    : '#E63946';
+
+  return (
+    <View style={[styles.card, { backgroundColor: theme.cardBackground }]}>
+      {/* Header */}
+      <View style={styles.header}>
+        <ThemedText style={[styles.title, { color: theme.text }]}>Symmetry Score</ThemedText>
+        {result.hasAnyWarning && (
+          <View style={[styles.alertBadge, { backgroundColor: '#E6394620' }]}>
+            <ThemedText style={styles.alertText}>⚠️ Deficit &gt;{WARNING_THRESHOLD}%</ThemedText>
+          </View>
+        )}
+      </View>
+
+      {/* Score Circle */}
+      <View style={styles.scoreRow}>
+        <View style={[styles.scoreCircle, { borderColor: scoreColor }]}>
+          <ThemedText style={[styles.scoreValue, { color: scoreColor }]}>
+            {result.symmetryScore}
+          </ThemedText>
+          <ThemedText style={[styles.scoreUnit, { color: theme.textSecondary }]}>/ 100</ThemedText>
+        </View>
+
+        <View style={styles.insightsCol}>
+          <View style={[styles.insightRow, { backgroundColor: theme.background }]}>
+            <ThemedText style={[styles.insightLabel, { color: theme.textSecondary }]}>VMO vs VL Balance</ThemedText>
+            <ThemedText style={[
+              styles.insightValue,
+              { color: result.vmoVlBalance > WARNING_THRESHOLD ? '#E63946' : theme.success }
+            ]}>
+              {result.vmoVlBalance}% gap
+            </ThemedText>
+          </View>
+          <View style={[styles.insightRow, { backgroundColor: theme.background }]}>
+            <ThemedText style={[styles.insightLabel, { color: theme.textSecondary }]}>Hamstring Guarding</ThemedText>
+            <ThemedText style={[
+              styles.insightValue,
+              { color: result.hamstringGuarding > 80 ? '#E63946' : theme.success }
+            ]}>
+              BF: {result.hamstringGuarding}%
+            </ThemedText>
+          </View>
+        </View>
+      </View>
+
+      {/* Per-channel breakdown */}
+      <View style={styles.channelGrid}>
+        {result.channels.map((ch) => (
+          <View
+            key={ch.channelIndex}
+            style={[
+              styles.channelChip,
+              {
+                backgroundColor: ch.hasWarning ? '#E6394615' : theme.background,
+                borderColor: ch.hasWarning ? '#E63946' : theme.border,
+              }
+            ]}
+          >
+            <ThemedText style={[styles.channelLabel, { color: theme.textSecondary }]}>
+              {ch.label}
+            </ThemedText>
+            <ThemedText style={[
+              styles.channelPct,
+              { color: ch.hasWarning ? '#E63946' : theme.text }
+            ]}>
+              {ch.normalizedPct}%
+            </ThemedText>
+            <ThemedText style={[
+              styles.channelDeficit,
+              { color: ch.hasWarning ? '#E63946' : theme.textSecondary }
+            ]}>
+              {ch.hasWarning ? `⚠️ -${ch.deficit}%` : `✓ -${ch.deficit}%`}
+            </ThemedText>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 20,
+    padding: 20,
+    marginBottom: 16,
+    gap: 16,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  title: { fontSize: 16, fontWeight: '700' },
+  alertBadge: {
+    paddingHorizontal: 10, paddingVertical: 4,
+    borderRadius: 12,
+  },
+  alertText: { fontSize: 12, color: '#E63946', fontWeight: '600' },
+  scoreRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+  },
+  scoreCircle: {
+    width: 90, height: 90, borderRadius: 45,
+    borderWidth: 4,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  scoreValue: { fontSize: 28, fontWeight: '800' },
+  scoreUnit: { fontSize: 11 },
+  insightsCol: { flex: 1, gap: 8 },
+  insightRow: {
+    flexDirection: 'row', justifyContent: 'space-between',
+    alignItems: 'center', padding: 10, borderRadius: 10,
+  },
+  insightLabel: { fontSize: 12, flex: 1 },
+  insightValue: { fontSize: 12, fontWeight: '700' },
+  channelGrid: {
+    flexDirection: 'row', flexWrap: 'wrap', gap: 8,
+  },
+  channelChip: {
+    width: '47%', borderWidth: 1, borderRadius: 12,
+    padding: 12, gap: 4,
+  },
+  channelLabel: { fontSize: 11, fontWeight: '600' },
+  channelPct: { fontSize: 20, fontWeight: '800' },
+  channelDeficit: { fontSize: 11 },
+});

--- a/smart-sleeve-app/components/dashboard/SymmetryCard.tsx
+++ b/smart-sleeve-app/components/dashboard/SymmetryCard.tsx
@@ -4,41 +4,41 @@ import { useColorScheme } from "@/hooks/use-color-scheme";
 import { Colors, Shadows, Typography } from "@/constants/theme";
 import { ThemedText } from "@/components/themed-text";
 import {
-  computeActivationInsights,
+  type BilateralComparisonResult,
   WARNING_THRESHOLD,
 } from "@/services/SymmetryService";
+import { EXERCISE_LIBRARY } from "@/constants/exercises";
 
 interface SymmetryCardProps {
-  normalizedPct: number[];
+  comparison: BilateralComparisonResult;
 }
 
-export default function SymmetryCard({ normalizedPct }: SymmetryCardProps) {
+export default function SymmetryCard({ comparison }: SymmetryCardProps) {
   const colorScheme = useColorScheme() ?? "light";
   const theme = Colors[colorScheme];
-
-  if (!normalizedPct || normalizedPct.length < 4) return null;
-
-  const result = computeActivationInsights(normalizedPct);
+  const exerciseName =
+    EXERCISE_LIBRARY.find((exercise) => exercise.id === comparison.exerciseType)
+      ?.name ?? comparison.exerciseType;
 
   const scoreColor =
-    result.activationScore >= 80
+    comparison.symmetryScore >= 85
       ? theme.success
-      : result.activationScore >= 60
-        ? theme.warning
-        : theme.text;
+      : comparison.symmetryScore >= 60
+        ? theme.text
+        : theme.warning;
 
   return (
     <View style={[styles.card, { backgroundColor: theme.cardBackground }]}>
       <View style={styles.header}>
         <View style={styles.headerCopy}>
           <ThemedText style={[styles.eyebrow, { color: theme.textSecondary }]}>
-            Single-Leg Insights
+            Bilateral Comparison
           </ThemedText>
           <ThemedText style={[styles.title, { color: theme.text }]}>
-            Muscle Activation
+            Symmetry Score
           </ThemedText>
         </View>
-        {result.hasAnyWarning && (
+        {comparison.hasAnyWarning && (
           <View
             style={[
               styles.alertBadge,
@@ -56,8 +56,9 @@ export default function SymmetryCard({ normalizedPct }: SymmetryCardProps) {
       </View>
 
       <ThemedText style={[styles.subtitle, { color: theme.textSecondary }]}>
-        Live % MVC snapshot for the instrumented leg. Use this to spot uneven
-        quad loading and hamstring over-activity.
+        Latest matched {exerciseName} sessions comparing the healthy{" "}
+        {comparison.healthySide.toLowerCase()} leg against the injured{" "}
+        {comparison.injuredSide.toLowerCase()} leg.
       </ThemedText>
 
       <View style={styles.scoreRow}>
@@ -70,10 +71,10 @@ export default function SymmetryCard({ normalizedPct }: SymmetryCardProps) {
           <ThemedText
             style={[styles.scoreLabel, { color: theme.textSecondary }]}
           >
-            Activation
+            Bilateral
           </ThemedText>
           <ThemedText style={[styles.scoreValue, { color: scoreColor }]}>
-            {result.activationScore}
+            {comparison.symmetryScore}
           </ThemedText>
           <ThemedText
             style={[styles.scoreUnit, { color: theme.textSecondary }]}
@@ -99,13 +100,13 @@ export default function SymmetryCard({ normalizedPct }: SymmetryCardProps) {
                 styles.insightValue,
                 {
                   color:
-                    result.vmoVlBalance > WARNING_THRESHOLD
+                    comparison.vmoVlBalance > WARNING_THRESHOLD
                       ? theme.warning
                       : theme.text,
                 },
               ]}
             >
-              {result.vmoVlBalance}% gap
+              {comparison.vmoVlBalance}% gap
             </ThemedText>
           </View>
           <View
@@ -124,43 +125,57 @@ export default function SymmetryCard({ normalizedPct }: SymmetryCardProps) {
                 styles.insightValue,
                 {
                   color:
-                    result.hamstringGuarding > 80 ? theme.warning : theme.text,
+                    comparison.hamstringGuarding > 0
+                      ? theme.warning
+                      : theme.text,
                 },
               ]}
             >
-              BF: {result.hamstringGuarding}%
+              {comparison.hamstringGuarding}% over healthy
             </ThemedText>
           </View>
         </View>
       </View>
 
       <View style={styles.channelGrid}>
-        {result.channels.map((ch) => (
+        {comparison.channels.map((channel) => (
           <View
-            key={ch.channelIndex}
+            key={channel.channelIndex}
             style={[
               styles.channelChip,
               {
                 backgroundColor: theme.secondaryCard,
-                borderColor: ch.hasWarning ? theme.warning : theme.border,
+                borderColor: channel.hasWarning ? theme.warning : theme.border,
               },
             ]}
           >
             <ThemedText
               style={[styles.channelLabel, { color: theme.textSecondary }]}
             >
-              {ch.label}
+              {channel.label}
             </ThemedText>
             <ThemedText style={[styles.channelPct, { color: theme.text }]}>
-              {ch.normalizedPct}%
+              Healthy {channel.healthyPct}%
+            </ThemedText>
+            <ThemedText
+              style={[
+                styles.channelPctSecondary,
+                { color: theme.textSecondary },
+              ]}
+            >
+              Injured {channel.injuredPct}%
             </ThemedText>
             <ThemedText
               style={[
                 styles.channelDeficit,
-                { color: ch.hasWarning ? theme.warning : theme.textSecondary },
+                {
+                  color: channel.hasWarning
+                    ? theme.warning
+                    : theme.textSecondary,
+                },
               ]}
             >
-              {ch.hasWarning ? `Target gap ${ch.targetGap}%` : "On target"}
+              Deficit {channel.deficit}%
             </ThemedText>
           </View>
         ))}
@@ -234,6 +249,7 @@ const styles = StyleSheet.create({
     gap: 4,
   },
   channelLabel: { fontSize: 11, fontWeight: "600" },
-  channelPct: { fontSize: 20, fontWeight: "800" },
+  channelPct: { fontSize: 18, fontWeight: "800" },
+  channelPctSecondary: { fontSize: 14, fontWeight: "600" },
   channelDeficit: { fontSize: 11 },
 });

--- a/smart-sleeve-app/components/dashboard/SymmetryCard.tsx
+++ b/smart-sleeve-app/components/dashboard/SymmetryCard.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { View, StyleSheet } from "react-native";
+import Svg, { Circle, Defs, LinearGradient, Stop } from "react-native-svg";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { Colors, Shadows, Typography } from "@/constants/theme";
 import { ThemedText } from "@/components/themed-text";
@@ -9,6 +10,12 @@ import {
 } from "@/services/SymmetryService";
 import { EXERCISE_LIBRARY } from "@/constants/exercises";
 
+// Arc gauge constants
+const GAUGE_SIZE = 140;
+const GAUGE_STROKE = 12;
+const GAUGE_RADIUS = (GAUGE_SIZE - GAUGE_STROKE) / 2;
+const GAUGE_CIRCUMFERENCE = GAUGE_RADIUS * 2 * Math.PI;
+
 interface SymmetryCardProps {
   comparison: BilateralComparisonResult;
 }
@@ -17,22 +24,22 @@ export default function SymmetryCard({ comparison }: SymmetryCardProps) {
   const colorScheme = useColorScheme() ?? "light";
   const theme = Colors[colorScheme];
   const exerciseName =
-    EXERCISE_LIBRARY.find((exercise) => exercise.id === comparison.exerciseType)
-      ?.name ?? comparison.exerciseType;
+    EXERCISE_LIBRARY.find((e) => e.id === comparison.exerciseType)?.name ??
+    comparison.exerciseType;
 
+  const score = comparison.symmetryScore;
   const scoreColor =
-    comparison.symmetryScore >= 85
-      ? theme.success
-      : comparison.symmetryScore >= 60
-        ? theme.text
-        : theme.warning;
+    score >= 85 ? theme.success : score >= 60 ? "#F59E0B" : theme.warning;
+  const strokeDashoffset =
+    GAUGE_CIRCUMFERENCE - (score / 100) * GAUGE_CIRCUMFERENCE;
 
   return (
     <View style={[styles.card, { backgroundColor: theme.cardBackground }]}>
+      {/* Header */}
       <View style={styles.header}>
-        <View style={styles.headerCopy}>
+        <View style={styles.headerLeft}>
           <ThemedText style={[styles.eyebrow, { color: theme.textSecondary }]}>
-            Bilateral Comparison
+            {exerciseName} · Bilateral Analysis
           </ThemedText>
           <ThemedText style={[styles.title, { color: theme.text }]}>
             Symmetry Score
@@ -41,144 +48,250 @@ export default function SymmetryCard({ comparison }: SymmetryCardProps) {
         {comparison.hasAnyWarning && (
           <View
             style={[
-              styles.alertBadge,
+              styles.warningPill,
               {
-                backgroundColor: theme.warning + "15",
-                borderColor: theme.warning,
+                backgroundColor: theme.warning + "10",
+                borderColor: theme.warning + "30",
               },
             ]}
           >
-            <ThemedText style={[styles.alertText, { color: theme.warning }]}>
-              Gap &gt; {WARNING_THRESHOLD}%
+            <ThemedText style={[styles.warningText, { color: theme.warning }]}>
+              Deficit Detected
             </ThemedText>
           </View>
         )}
       </View>
 
-      <ThemedText style={[styles.subtitle, { color: theme.textSecondary }]}>
-        Latest matched {exerciseName} sessions comparing the healthy{" "}
-        {comparison.healthySide.toLowerCase()} leg against the injured{" "}
-        {comparison.injuredSide.toLowerCase()} leg.
-      </ThemedText>
-
+      {/* Score gauge + insights */}
       <View style={styles.scoreRow}>
-        <View
-          style={[
-            styles.scoreCircle,
-            { borderColor: scoreColor, backgroundColor: theme.secondaryCard },
-          ]}
-        >
-          <ThemedText
-            style={[styles.scoreLabel, { color: theme.textSecondary }]}
+        {/* SVG arc gauge */}
+        <View style={styles.gaugeWrap}>
+          <Svg
+            width={GAUGE_SIZE}
+            height={GAUGE_SIZE}
+            viewBox={`0 0 ${GAUGE_SIZE} ${GAUGE_SIZE}`}
           >
-            Bilateral
-          </ThemedText>
-          <ThemedText style={[styles.scoreValue, { color: scoreColor }]}>
-            {comparison.symmetryScore}
-          </ThemedText>
-          <ThemedText
-            style={[styles.scoreUnit, { color: theme.textSecondary }]}
-          >
-            out of 100
-          </ThemedText>
-        </View>
-
-        <View style={styles.insightsCol}>
-          <View
-            style={[
-              styles.insightRow,
-              { backgroundColor: theme.secondaryCard },
-            ]}
-          >
-            <ThemedText
-              style={[styles.insightLabel, { color: theme.textSecondary }]}
-            >
-              Quad Balance
+            <Defs>
+              <LinearGradient id="scoreGrad" x1="0" y1="0" x2="0" y2="1">
+                <Stop offset="0" stopColor={scoreColor} stopOpacity="1" />
+                <Stop offset="1" stopColor={scoreColor} stopOpacity="0.8" />
+              </LinearGradient>
+            </Defs>
+            <Circle
+              cx={GAUGE_SIZE / 2}
+              cy={GAUGE_SIZE / 2}
+              r={GAUGE_RADIUS}
+              stroke={theme.border}
+              strokeWidth={GAUGE_STROKE}
+              fill="none"
+              strokeOpacity={0.15}
+            />
+            <Circle
+              cx={GAUGE_SIZE / 2}
+              cy={GAUGE_SIZE / 2}
+              r={GAUGE_RADIUS}
+              stroke="url(#scoreGrad)"
+              strokeWidth={GAUGE_STROKE}
+              fill="none"
+              strokeDasharray={GAUGE_CIRCUMFERENCE}
+              strokeDashoffset={strokeDashoffset}
+              strokeLinecap="round"
+              transform={`rotate(-90 ${GAUGE_SIZE / 2} ${GAUGE_SIZE / 2})`}
+            />
+          </Svg>
+          <View style={styles.gaugeInner}>
+            <ThemedText style={[styles.gaugeScore, { color: theme.text }]}>
+              {score}
             </ThemedText>
             <ThemedText
-              style={[
-                styles.insightValue,
-                {
-                  color:
-                    comparison.vmoVlBalance > WARNING_THRESHOLD
-                      ? theme.warning
-                      : theme.text,
-                },
-              ]}
+              style={[styles.gaugeUnit, { color: theme.textSecondary }]}
             >
-              {comparison.vmoVlBalance}% gap
+              pts
             </ThemedText>
           </View>
+        </View>
+
+        {/* Insight rows + side labels */}
+        <View style={styles.insightsCol}>
+          <InsightRow
+            label="Quad Balance"
+            value={`${comparison.vmoVlBalance}%`}
+            suffix="gap"
+            isWarning={comparison.vmoVlBalance > WARNING_THRESHOLD}
+            theme={theme}
+          />
+          <InsightRow
+            label="Hamstring Load"
+            value={`${comparison.hamstringGuarding}%`}
+            suffix="shift"
+            isWarning={comparison.hamstringGuarding > 0}
+            theme={theme}
+          />
+          {/* Healthy vs Injured leg labels */}
           <View
-            style={[
-              styles.insightRow,
-              { backgroundColor: theme.secondaryCard },
-            ]}
+            style={[styles.sidesRow, { backgroundColor: theme.secondaryCard }]}
           >
-            <ThemedText
-              style={[styles.insightLabel, { color: theme.textSecondary }]}
-            >
-              Hamstring Load
-            </ThemedText>
-            <ThemedText
-              style={[
-                styles.insightValue,
-                {
-                  color:
-                    comparison.hamstringGuarding > 0
-                      ? theme.warning
-                      : theme.text,
-                },
-              ]}
-            >
-              {comparison.hamstringGuarding}% over healthy
-            </ThemedText>
+            <View style={styles.sideBadge}>
+              <View
+                style={[styles.sideDot, { backgroundColor: theme.success }]}
+              />
+              <ThemedText
+                style={[styles.sideLabel, { color: theme.textSecondary }]}
+              >
+                Healthy
+              </ThemedText>
+              <ThemedText style={[styles.sideSide, { color: theme.text }]}>
+                {comparison.healthySide[0]}
+              </ThemedText>
+            </View>
+            <View
+              style={[styles.sidesDivider, { backgroundColor: theme.border, opacity: 0.5 }]}
+            />
+            <View style={styles.sideBadge}>
+              <View
+                style={[styles.sideDot, { backgroundColor: theme.warning }]}
+              />
+              <ThemedText
+                style={[styles.sideLabel, { color: theme.textSecondary }]}
+              >
+                Injured
+              </ThemedText>
+              <ThemedText style={[styles.sideSide, { color: theme.text }]}>
+                {comparison.injuredSide[0]}
+              </ThemedText>
+            </View>
           </View>
         </View>
       </View>
 
+      {/* Per-muscle channel chips with bar comparisons */}
       <View style={styles.channelGrid}>
-        {comparison.channels.map((channel) => (
-          <View
-            key={channel.channelIndex}
-            style={[
-              styles.channelChip,
-              {
-                backgroundColor: theme.secondaryCard,
-                borderColor: channel.hasWarning ? theme.warning : theme.border,
-              },
-            ]}
-          >
-            <ThemedText
-              style={[styles.channelLabel, { color: theme.textSecondary }]}
-            >
-              {channel.label}
-            </ThemedText>
-            <ThemedText style={[styles.channelPct, { color: theme.text }]}>
-              Healthy {channel.healthyPct}%
-            </ThemedText>
-            <ThemedText
-              style={[
-                styles.channelPctSecondary,
-                { color: theme.textSecondary },
-              ]}
-            >
-              Injured {channel.injuredPct}%
-            </ThemedText>
-            <ThemedText
-              style={[
-                styles.channelDeficit,
-                {
-                  color: channel.hasWarning
-                    ? theme.warning
-                    : theme.textSecondary,
-                },
-              ]}
-            >
-              Deficit {channel.deficit}%
-            </ThemedText>
-          </View>
+        {comparison.channels.map((ch) => (
+          <ChannelChip key={ch.channelIndex} channel={ch} theme={theme} />
         ))}
+      </View>
+    </View>
+  );
+}
+
+// ── Sub-components ──────────────────────────────────────────────────────────
+
+function InsightRow({
+  label,
+  value,
+  suffix,
+  isWarning,
+  theme,
+}: {
+  label: string;
+  value: string;
+  suffix: string;
+  isWarning: boolean;
+  theme: (typeof Colors)["light"];
+}) {
+  const color = isWarning ? theme.warning : theme.success;
+  return (
+    <View
+      style={[styles.insightRow, { backgroundColor: theme.secondaryCard + "50" }]}
+    >
+      <ThemedText style={[styles.insightLabel, { color: theme.textSecondary }]}>
+        {label}
+      </ThemedText>
+      <View style={styles.insightValueRow}>
+        <ThemedText style={[styles.insightValue, { color }]}>
+          {value}
+        </ThemedText>
+        <ThemedText
+          style={[styles.insightSuffix, { color: theme.textSecondary }]}
+        >
+          {" "}
+          {suffix}
+        </ThemedText>
+      </View>
+    </View>
+  );
+}
+
+function ChannelChip({
+  channel,
+  theme,
+}: {
+  channel: BilateralComparisonResult["channels"][number];
+  theme: (typeof Colors)["light"];
+}) {
+  const barColor = channel.hasWarning ? theme.warning : theme.success;
+  const healthyWidth = `${Math.min(channel.healthyPct, 100)}%` as const;
+  const injuredWidth = `${Math.min(channel.injuredPct, 100)}%` as const;
+
+  return (
+    <View
+      style={[
+        styles.chip,
+        {
+          backgroundColor: theme.cardBackground,
+          borderColor: channel.hasWarning
+            ? theme.warning + "40"
+            : "rgba(0,0,0,0.05)",
+        },
+      ]}
+    >
+      <ThemedText style={[styles.chipLabel, { color: theme.textSecondary }]}>
+        {channel.label}
+      </ThemedText>
+
+      <View style={styles.barContainer}>
+        {/* Healthy bar */}
+        <View style={styles.barRow}>
+          <View style={[styles.barTrack, { backgroundColor: theme.border, opacity: 0.3 }]}>
+            <View
+              style={[
+                styles.barFill,
+                { width: healthyWidth, backgroundColor: theme.success },
+              ]}
+            />
+          </View>
+          <ThemedText style={[styles.barValue, { color: theme.text }]}>
+            {channel.healthyPct}%
+          </ThemedText>
+        </View>
+
+        {/* Injured bar */}
+        <View style={styles.barRow}>
+          <View style={[styles.barTrack, { backgroundColor: theme.border, opacity: 0.3 }]}>
+            <View
+              style={[
+                styles.barFill,
+                { width: injuredWidth, backgroundColor: barColor },
+              ]}
+            />
+          </View>
+          <ThemedText style={[styles.barValue, { color: theme.textSecondary }]}>
+            {channel.injuredPct}%
+          </ThemedText>
+        </View>
+      </View>
+
+      {/* Deficit badge */}
+      <View
+        style={[
+          styles.deficitBadge,
+          {
+            backgroundColor: channel.hasWarning
+              ? theme.warning + "10"
+              : theme.success + "08",
+          },
+        ]}
+      >
+        <ThemedText
+          style={[
+            styles.deficitText,
+            {
+              color: channel.hasWarning ? theme.warning : theme.success,
+            },
+          ]}
+        >
+          {channel.deficit}% deficit
+        </ThemedText>
       </View>
     </View>
   );
@@ -187,69 +300,183 @@ export default function SymmetryCard({ comparison }: SymmetryCardProps) {
 const styles = StyleSheet.create({
   card: {
     borderRadius: 24,
-    padding: 20,
-    marginBottom: 16,
-    gap: 16,
+    padding: 24,
+    marginBottom: 20,
+    gap: 20,
     ...Shadows.card,
+    borderWidth: 1,
+    borderColor: "rgba(0,0,0,0.02)",
   },
+
+  // Header
   header: {
     flexDirection: "row",
-    gap: 12,
-    alignItems: "center",
+    alignItems: "flex-start",
     justifyContent: "space-between",
   },
-  headerCopy: { flex: 1, gap: 2 },
-  eyebrow: { ...Typography.label },
-  title: { ...Typography.heading3 },
-  subtitle: { ...Typography.caption },
-  alertBadge: {
-    paddingHorizontal: 10,
-    paddingVertical: 4,
+  headerLeft: { gap: 4 },
+  eyebrow: { 
+    ...Typography.label,
+    fontSize: 10,
+    letterSpacing: 1,
+  },
+  title: { 
+    ...Typography.heading3,
+    fontSize: 20,
+  },
+  warningPill: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
     borderRadius: 12,
     borderWidth: 1,
   },
-  alertText: { fontSize: 12, fontWeight: "600" },
+  warningText: { 
+    ...Typography.label,
+    fontSize: 10,
+    textTransform: "none",
+  },
+
+  // Score row
   scoreRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 16,
+    gap: 20,
   },
-  scoreCircle: {
-    width: 112,
-    height: 112,
-    borderRadius: 56,
-    borderWidth: 3,
+
+  // SVG gauge
+  gaugeWrap: {
+    width: GAUGE_SIZE,
+    height: GAUGE_SIZE,
     alignItems: "center",
     justifyContent: "center",
-    paddingHorizontal: 12,
   },
-  scoreLabel: { ...Typography.label },
-  scoreValue: { fontSize: 30, fontWeight: "800" },
-  scoreUnit: { fontSize: 11, textAlign: "center" },
-  insightsCol: { flex: 1, gap: 8 },
+  gaugeInner: {
+    position: "absolute",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  gaugeScore: { 
+    ...Typography.heading1,
+    fontSize: 36,
+    lineHeight: 42,
+  },
+  gaugeUnit: { 
+    ...Typography.label,
+    fontSize: 10,
+    marginTop: -4,
+  },
+
+  // Insights
+  insightsCol: { flex: 1, gap: 10 },
   insightRow: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    padding: 10,
-    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 12,
   },
-  insightLabel: { fontSize: 12, flex: 1 },
-  insightValue: { fontSize: 12, fontWeight: "700" },
+  insightLabel: { 
+    ...Typography.caption,
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  insightValueRow: { flexDirection: "row", alignItems: "baseline" },
+  insightValue: { 
+    ...Typography.bodyBold,
+    fontSize: 14,
+  },
+  insightSuffix: { 
+    ...Typography.caption,
+    fontSize: 10,
+    opacity: 0.8,
+  },
+
+  // Side badges row
+  sidesRow: {
+    flexDirection: "row",
+    borderRadius: 12,
+    overflow: "hidden",
+    alignItems: "center",
+    marginTop: 4,
+  },
+  sideBadge: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  sideDot: { width: 8, height: 8, borderRadius: 4 },
+  sideLabel: { 
+    ...Typography.label,
+    fontSize: 9,
+    textTransform: "uppercase",
+    opacity: 0.7,
+  },
+  sideSide: { 
+    ...Typography.bodyBold,
+    fontSize: 12,
+  },
+  sidesDivider: { width: 1, height: 16 },
+
+  // Channel grid
   channelGrid: {
     flexDirection: "row",
     flexWrap: "wrap",
+    gap: 12,
+  },
+
+  // Channel chip
+  chip: {
+    flex: 1,
+    minWidth: "45%",
+    borderWidth: 1,
+    borderRadius: 20,
+    padding: 16,
+    gap: 12,
+    ...Shadows.card,
+    shadowOpacity: 0.03,
+  },
+  chipLabel: { 
+    ...Typography.label,
+    fontSize: 11,
+    letterSpacing: 0.5,
+  },
+  barContainer: {
     gap: 8,
   },
-  channelChip: {
-    width: "47%",
-    borderWidth: 1,
-    borderRadius: 12,
-    padding: 12,
-    gap: 4,
+  barRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
   },
-  channelLabel: { fontSize: 11, fontWeight: "600" },
-  channelPct: { fontSize: 18, fontWeight: "800" },
-  channelPctSecondary: { fontSize: 14, fontWeight: "600" },
-  channelDeficit: { fontSize: 11 },
+  barTrack: {
+    flex: 1,
+    height: 6,
+    borderRadius: 3,
+    overflow: "hidden",
+  },
+  barFill: {
+    height: 6,
+    borderRadius: 3,
+  },
+  barValue: { 
+    ...Typography.label,
+    fontSize: 10,
+    width: 28,
+    textAlign: "right",
+  },
+  deficitBadge: {
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    alignSelf: "flex-start",
+  },
+  deficitText: { 
+    ...Typography.label,
+    fontSize: 10,
+    textTransform: "none",
+  },
 });

--- a/smart-sleeve-app/hooks/useWorkoutSession.ts
+++ b/smart-sleeve-app/hooks/useWorkoutSession.ts
@@ -11,7 +11,7 @@ import {
   selectWorkout,
 } from "@/store/deviceSlice";
 import { saveSession, SaveSessionResult } from "@/services/SessionService";
-import { selectCalibration, selectIsCalibrated } from "@/store/userSlice";
+import { selectCalibrationForSide } from "@/store/userSlice";
 
 /**
  * Custom hook to manage the lifecycle of a workout recording session.
@@ -25,8 +25,10 @@ export function useWorkoutSession() {
   const kneeAngles = useSelector(selectRecordingKneeAngles);
   const sessionStartTime = useSelector(selectSessionStartTime);
   const workout = useSelector(selectWorkout);
-  const calibration = useSelector(selectCalibration);
-  const isCalibrated = useSelector(selectIsCalibrated);
+  const calibration = useSelector((state: any) =>
+    selectCalibrationForSide(state, workout.targetSide ?? "LEFT"),
+  );
+  const isCalibrated = calibration.calibratedAt !== null;
 
   const startRecording = () => {
     dispatch(startSession());

--- a/smart-sleeve-app/services/Database.ts
+++ b/smart-sleeve-app/services/Database.ts
@@ -36,6 +36,7 @@ export interface SessionAnalytics {
   exerciseQuality: number;
   completionRate?: number;
   intensityScore?: number;
+  normalizedChannelMeans?: number[] | null;
 }
 
 export interface Session {
@@ -135,6 +136,7 @@ export async function initDatabase(): Promise<void> {
         exercise_quality    REAL NOT NULL DEFAULT 0,
         completion_rate     REAL NOT NULL DEFAULT 0,
         intensity_score     REAL NOT NULL DEFAULT 0,
+        normalized_channel_means TEXT NOT NULL DEFAULT '[]',
         synced              INTEGER NOT NULL DEFAULT 0,
         FOREIGN KEY (user_id) REFERENCES users(id)
       );
@@ -211,8 +213,8 @@ export async function insertSession(
       completed_reps, target_reps,
       exercise_ids, avg_activation, max_activation, deficit_percentage,
       fatigue_score, rom_degrees, exercise_quality, completion_rate,
-      intensity_score, synced
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      intensity_score, normalized_channel_means, synced
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       session.id,
       session.userId,
@@ -232,6 +234,7 @@ export async function insertSession(
       a.exerciseQuality,
       a.completionRate ?? 0,
       a.intensityScore ?? 0,
+      JSON.stringify(a.normalizedChannelMeans ?? []),
       session.synced ? 1 : 0,
     ],
   );
@@ -416,6 +419,7 @@ function rowToSession(row: any): Session {
       exerciseQuality: row.exercise_quality,
       completionRate: row.completion_rate ?? 0,
       intensityScore: row.intensity_score ?? 0,
+      normalizedChannelMeans: JSON.parse(row.normalized_channel_means ?? "[]"),
     },
   };
 }
@@ -441,6 +445,10 @@ async function ensureSessionColumns(db: SQLite.SQLiteDatabase): Promise<void> {
     {
       name: "intensity_score",
       sql: `ALTER TABLE sessions ADD COLUMN intensity_score REAL NOT NULL DEFAULT 0`,
+    },
+    {
+      name: "normalized_channel_means",
+      sql: `ALTER TABLE sessions ADD COLUMN normalized_channel_means TEXT NOT NULL DEFAULT '[]'`,
     },
   ];
 

--- a/smart-sleeve-app/services/SessionService.ts
+++ b/smart-sleeve-app/services/SessionService.ts
@@ -24,6 +24,7 @@ import {
   computeDeficitPercentageFromEMGFrames,
   computeIntensityScore,
 } from "@/services/ProgressAnalysis";
+import { normalize } from "@/services/NormalizationService";
 import type { CalibrationCoefficients } from "@/store/userSlice";
 
 export interface SaveSessionParams {
@@ -116,6 +117,10 @@ export async function saveSession(
     emgBuffer,
     kneeAngleBuffer,
   );
+  const normalizedChannelMeans = computeNormalizedChannelMeans(
+    emgBuffer,
+    calibration,
+  );
 
   // ── Compute analytics from buffer ──────────────────────────────────────────
   const rmsValues = emgBuffer.map((frame) => frame.channels.slice(0, 4));
@@ -171,6 +176,7 @@ export async function saveSession(
       exerciseQuality: exerciseQuality > 0 ? exerciseQuality : 0.85, // fallback to a good score
       completionRate: 0,
       intensityScore: 0,
+      normalizedChannelMeans,
     },
   };
 
@@ -240,6 +246,28 @@ function average(arr: number[]): number {
   return arr.reduce((a, b) => a + b, 0) / arr.length;
 }
 
-function computeMean(arr: number[]): number {
-  return average(arr);
+function computeNormalizedChannelMeans(
+  emgBuffer: EMGData[],
+  calibration?: CalibrationCoefficients | null,
+): number[] | null {
+  if (
+    !calibration ||
+    calibration.calibratedAt === null ||
+    emgBuffer.length === 0
+  ) {
+    return null;
+  }
+
+  const channelTotals = [0, 0, 0, 0];
+
+  for (const frame of emgBuffer) {
+    const normalizedChannels = normalize(frame.channels, calibration);
+    for (let channelIndex = 0; channelIndex < 4; channelIndex += 1) {
+      channelTotals[channelIndex] += normalizedChannels[channelIndex] ?? 0;
+    }
+  }
+
+  return channelTotals.map(
+    (total) => Math.round((total / emgBuffer.length) * 10) / 10,
+  );
 }

--- a/smart-sleeve-app/services/SymmetryService.ts
+++ b/smart-sleeve-app/services/SymmetryService.ts
@@ -1,53 +1,62 @@
-// SymmetryService.ts
-// Computes bilateral muscle symmetry metrics from normalized % MVC values.
-// Since the sleeve has 4 channels on one leg, we compare:
-//   - VMO (ch0) vs VL (ch1): quad balance
-//   - Semitendinosus (ch2) vs Biceps Femoris (ch3): hamstring balance
-//   - Overall symmetry score: how close all channels are to 100% MVC target
+// Computes single-leg muscle activation insights from normalized % MVC values.
+// The app currently streams one four-channel sleeve, so this service reports
+// same-leg activation quality and muscle-balance signals instead of bilateral symmetry.
 
-export const WARNING_THRESHOLD = 30; // % deficit to trigger red warning
+export const WARNING_THRESHOLD = 30; // % below MVC target to trigger a warning
 
-export interface ChannelSymmetry {
+export interface ChannelActivationInsight {
   channelIndex: number;
   label: string;
   normalizedPct: number;
-  deficit: number;        // |100 - normalizedPct|
-  hasWarning: boolean;    // deficit > WARNING_THRESHOLD
+  targetGap: number;
+  hasWarning: boolean;
 }
 
-export interface SymmetryResult {
-  symmetryScore: number;          // 0-100%
-  channels: ChannelSymmetry[];
-  vmoVlBalance: number;           // |VMO% - VL%|
-  hamstringGuarding: number;      // BF% (high = over-active)
+export interface ActivationInsightResult {
+  activationScore: number;
+  channels: ChannelActivationInsight[];
+  vmoVlBalance: number;
+  hamstringGuarding: number;
   hasAnyWarning: boolean;
 }
 
-const CHANNEL_LABELS = ['VMO', 'VL', 'Semitendinosus', 'Biceps Femoris'];
+const CHANNEL_LABELS = ["VMO", "VL", "ST", "BF"];
 
-export function computeSymmetry(normalizedPct: number[]): SymmetryResult {
-  const channels: ChannelSymmetry[] = normalizedPct.slice(0, 4).map((pct, i) => {
-    const deficit = Math.abs(100 - pct);
-    return {
-      channelIndex: i,
-      label: CHANNEL_LABELS[i],
-      normalizedPct: Math.round(pct),
-      deficit: Math.round(deficit),
-      hasWarning: deficit > WARNING_THRESHOLD,
-    };
-  });
+export function computeActivationInsights(
+  normalizedPct: number[],
+): ActivationInsightResult {
+  const channels: ChannelActivationInsight[] = normalizedPct
+    .slice(0, 4)
+    .map((pct, index) => {
+      const roundedPct = Math.round(pct);
+      const targetGap = Math.max(0, Math.round(100 - pct));
 
-  // Average deficit across all 4 channels → symmetry score
-  const avgDeficit = channels.reduce((sum, ch) => sum + ch.deficit, 0) / channels.length;
-  const symmetryScore = Math.max(0, Math.round(100 - avgDeficit));
+      return {
+        channelIndex: index,
+        label: CHANNEL_LABELS[index],
+        normalizedPct: roundedPct,
+        targetGap,
+        hasWarning: targetGap > WARNING_THRESHOLD,
+      };
+    });
 
-  // VMO vs VL quad balance
-  const vmoVlBalance = Math.round(Math.abs(channels[0].normalizedPct - channels[1].normalizedPct));
-
-  // Biceps Femoris activity (high = hamstring guarding)
+  const activationScore = Math.round(
+    channels.reduce(
+      (sum, channel) => sum + Math.min(channel.normalizedPct, 100),
+      0,
+    ) / channels.length,
+  );
+  const vmoVlBalance = Math.round(
+    Math.abs(channels[0].normalizedPct - channels[1].normalizedPct),
+  );
   const hamstringGuarding = Math.round(channels[3].normalizedPct);
+  const hasAnyWarning = channels.some((channel) => channel.hasWarning);
 
-  const hasAnyWarning = channels.some(ch => ch.hasWarning);
-
-  return { symmetryScore, channels, vmoVlBalance, hamstringGuarding, hasAnyWarning };
+  return {
+    activationScore,
+    channels,
+    vmoVlBalance,
+    hamstringGuarding,
+    hasAnyWarning,
+  };
 }

--- a/smart-sleeve-app/services/SymmetryService.ts
+++ b/smart-sleeve-app/services/SymmetryService.ts
@@ -1,0 +1,53 @@
+// SymmetryService.ts
+// Computes bilateral muscle symmetry metrics from normalized % MVC values.
+// Since the sleeve has 4 channels on one leg, we compare:
+//   - VMO (ch0) vs VL (ch1): quad balance
+//   - Semitendinosus (ch2) vs Biceps Femoris (ch3): hamstring balance
+//   - Overall symmetry score: how close all channels are to 100% MVC target
+
+export const WARNING_THRESHOLD = 30; // % deficit to trigger red warning
+
+export interface ChannelSymmetry {
+  channelIndex: number;
+  label: string;
+  normalizedPct: number;
+  deficit: number;        // |100 - normalizedPct|
+  hasWarning: boolean;    // deficit > WARNING_THRESHOLD
+}
+
+export interface SymmetryResult {
+  symmetryScore: number;          // 0-100%
+  channels: ChannelSymmetry[];
+  vmoVlBalance: number;           // |VMO% - VL%|
+  hamstringGuarding: number;      // BF% (high = over-active)
+  hasAnyWarning: boolean;
+}
+
+const CHANNEL_LABELS = ['VMO', 'VL', 'Semitendinosus', 'Biceps Femoris'];
+
+export function computeSymmetry(normalizedPct: number[]): SymmetryResult {
+  const channels: ChannelSymmetry[] = normalizedPct.slice(0, 4).map((pct, i) => {
+    const deficit = Math.abs(100 - pct);
+    return {
+      channelIndex: i,
+      label: CHANNEL_LABELS[i],
+      normalizedPct: Math.round(pct),
+      deficit: Math.round(deficit),
+      hasWarning: deficit > WARNING_THRESHOLD,
+    };
+  });
+
+  // Average deficit across all 4 channels → symmetry score
+  const avgDeficit = channels.reduce((sum, ch) => sum + ch.deficit, 0) / channels.length;
+  const symmetryScore = Math.max(0, Math.round(100 - avgDeficit));
+
+  // VMO vs VL quad balance
+  const vmoVlBalance = Math.round(Math.abs(channels[0].normalizedPct - channels[1].normalizedPct));
+
+  // Biceps Femoris activity (high = hamstring guarding)
+  const hamstringGuarding = Math.round(channels[3].normalizedPct);
+
+  const hasAnyWarning = channels.some(ch => ch.hasWarning);
+
+  return { symmetryScore, channels, vmoVlBalance, hamstringGuarding, hasAnyWarning };
+}

--- a/smart-sleeve-app/services/SymmetryService.ts
+++ b/smart-sleeve-app/services/SymmetryService.ts
@@ -1,62 +1,126 @@
-// Computes single-leg muscle activation insights from normalized % MVC values.
-// The app currently streams one four-channel sleeve, so this service reports
-// same-leg activation quality and muscle-balance signals instead of bilateral symmetry.
+import type { Session } from "@/services/Database";
+import type { InjuredSide } from "@/store/userSlice";
 
-export const WARNING_THRESHOLD = 30; // % below MVC target to trigger a warning
+export const WARNING_THRESHOLD = 30;
 
-export interface ChannelActivationInsight {
+export interface BilateralChannelComparison {
   channelIndex: number;
   label: string;
-  normalizedPct: number;
-  targetGap: number;
+  healthyPct: number;
+  injuredPct: number;
+  deficit: number;
   hasWarning: boolean;
 }
 
-export interface ActivationInsightResult {
-  activationScore: number;
-  channels: ChannelActivationInsight[];
+export interface BilateralComparisonResult {
+  symmetryScore: number;
+  channels: BilateralChannelComparison[];
   vmoVlBalance: number;
   hamstringGuarding: number;
   hasAnyWarning: boolean;
+  exerciseType: string;
+  healthySide: InjuredSide;
+  injuredSide: InjuredSide;
+  healthySessionId: string;
+  injuredSessionId: string;
 }
 
 const CHANNEL_LABELS = ["VMO", "VL", "ST", "BF"];
 
-export function computeActivationInsights(
-  normalizedPct: number[],
-): ActivationInsightResult {
-  const channels: ChannelActivationInsight[] = normalizedPct
-    .slice(0, 4)
-    .map((pct, index) => {
-      const roundedPct = Math.round(pct);
-      const targetGap = Math.max(0, Math.round(100 - pct));
+function getNormalizedChannelMeans(session: Session): number[] | null {
+  const normalizedChannelMeans = session.analytics.normalizedChannelMeans;
+
+  if (!normalizedChannelMeans || normalizedChannelMeans.length < 4) {
+    return null;
+  }
+
+  return normalizedChannelMeans.slice(0, 4).map((value) => Math.round(value));
+}
+
+export function buildBilateralComparison(
+  healthySession: Session,
+  injuredSession: Session,
+): BilateralComparisonResult {
+  const healthyMeans = getNormalizedChannelMeans(healthySession);
+  const injuredMeans = getNormalizedChannelMeans(injuredSession);
+
+  if (!healthyMeans || !injuredMeans) {
+    throw new Error(
+      "Both sessions need normalized channel summaries for bilateral comparison.",
+    );
+  }
+
+  const channels: BilateralChannelComparison[] = CHANNEL_LABELS.map(
+    (label, channelIndex) => {
+      const healthyPct = healthyMeans[channelIndex] ?? 0;
+      const injuredPct = injuredMeans[channelIndex] ?? 0;
+      const deficit = Math.max(0, healthyPct - injuredPct);
 
       return {
-        channelIndex: index,
-        label: CHANNEL_LABELS[index],
-        normalizedPct: roundedPct,
-        targetGap,
-        hasWarning: targetGap > WARNING_THRESHOLD,
+        channelIndex,
+        label,
+        healthyPct,
+        injuredPct,
+        deficit,
+        hasWarning: deficit > WARNING_THRESHOLD,
       };
-    });
+    },
+  );
 
-  const activationScore = Math.round(
-    channels.reduce(
-      (sum, channel) => sum + Math.min(channel.normalizedPct, 100),
-      0,
-    ) / channels.length,
+  const averageDeficit =
+    channels.reduce((sum, channel) => sum + channel.deficit, 0) /
+    channels.length;
+  const symmetryScore = Math.max(0, Math.round(100 - averageDeficit));
+  const vmoVlBalance = Math.abs(
+    (injuredMeans[0] ?? 0) - (injuredMeans[1] ?? 0),
   );
-  const vmoVlBalance = Math.round(
-    Math.abs(channels[0].normalizedPct - channels[1].normalizedPct),
+  const hamstringGuarding = Math.max(
+    0,
+    (injuredMeans[3] ?? 0) - (healthyMeans[3] ?? 0),
   );
-  const hamstringGuarding = Math.round(channels[3].normalizedPct);
   const hasAnyWarning = channels.some((channel) => channel.hasWarning);
 
   return {
-    activationScore,
+    symmetryScore,
     channels,
     vmoVlBalance,
     hamstringGuarding,
     hasAnyWarning,
+    exerciseType: injuredSession.exerciseType,
+    healthySide: healthySession.side,
+    injuredSide: injuredSession.side,
+    healthySessionId: healthySession.id,
+    injuredSessionId: injuredSession.id,
   };
+}
+
+export function findLatestBilateralComparison(
+  sessions: Session[],
+  injuredSide: InjuredSide,
+): BilateralComparisonResult | null {
+  const healthySide = injuredSide === "LEFT" ? "RIGHT" : "LEFT";
+  const injuredSessions = sessions
+    .filter(
+      (session) =>
+        session.side === injuredSide &&
+        getNormalizedChannelMeans(session) !== null,
+    )
+    .sort((left, right) => right.timestamp - left.timestamp);
+
+  for (const injuredSession of injuredSessions) {
+    const healthySession = sessions
+      .filter(
+        (session) =>
+          session.side === healthySide &&
+          session.exerciseType === injuredSession.exerciseType &&
+          getNormalizedChannelMeans(session) !== null,
+      )
+      .sort((left, right) => right.timestamp - left.timestamp)[0];
+
+    if (healthySession) {
+      return buildBilateralComparison(healthySession, injuredSession);
+    }
+  }
+
+  return null;
 }

--- a/smart-sleeve-app/store/migrations.ts
+++ b/smart-sleeve-app/store/migrations.ts
@@ -4,6 +4,11 @@ const DEFAULT_CALIBRATION = {
   calibratedAt: null,
 };
 
+const createDefaultCalibrationsBySide = () => ({
+  LEFT: { ...DEFAULT_CALIBRATION },
+  RIGHT: { ...DEFAULT_CALIBRATION },
+});
+
 const getUserState = (state: any) => state?.user ?? {};
 
 export const migrations: Record<number, (state: any) => any> = {
@@ -51,6 +56,33 @@ export const migrations: Record<number, (state: any) => any> = {
       user: {
         ...user,
         profileOwnerEmail: user.profileOwnerEmail ?? user.email ?? null,
+      },
+    };
+  },
+  6: (state: any) => {
+    const user = getUserState(state);
+    const legacyCalibration = user.calibration ?? DEFAULT_CALIBRATION;
+    const injuredSide = user.injuredSide ?? null;
+    const legacyMeasurementSide = user.measurementSide ?? injuredSide ?? null;
+    const existingCalibrations = user.calibrationsBySide;
+
+    const calibrationsBySide = existingCalibrations ?? {
+      ...createDefaultCalibrationsBySide(),
+      ...(injuredSide
+        ? {
+            [injuredSide]: legacyCalibration,
+          }
+        : {
+            LEFT: legacyCalibration,
+          }),
+    };
+
+    return {
+      ...state,
+      user: {
+        ...user,
+        calibrationsBySide,
+        measurementSide: legacyMeasurementSide,
       },
     };
   },

--- a/smart-sleeve-app/store/migrations.ts
+++ b/smart-sleeve-app/store/migrations.ts
@@ -26,13 +26,15 @@ export const migrations: Record<number, (state: any) => any> = {
   },
   3: (state: any) => {
     const user = getUserState(state);
+    const injuredSide = user.injuredSide ?? null;
 
     return {
       ...state,
       user: {
         ...user,
-        injuredSide: user.injuredSide ?? null,
-        hasCompletedOnboarding: user.hasCompletedOnboarding ?? true,
+        injuredSide,
+        hasCompletedOnboarding:
+          user.hasCompletedOnboarding ?? injuredSide !== null,
       },
     };
   },

--- a/smart-sleeve-app/store/store.ts
+++ b/smart-sleeve-app/store/store.ts
@@ -29,7 +29,7 @@ const storage =
 const rootPersistConfig = {
   key: "root",
   storage,
-  version: 5,
+  version: 6,
   migrate: createMigrate(migrations, { debug: false }),
   whitelist: ["user"],
 };

--- a/smart-sleeve-app/store/userSlice.ts
+++ b/smart-sleeve-app/store/userSlice.ts
@@ -9,6 +9,11 @@ export interface CalibrationCoefficients {
 
 export type InjuredSide = "LEFT" | "RIGHT";
 
+export interface CalibrationsBySide {
+  LEFT: CalibrationCoefficients;
+  RIGHT: CalibrationCoefficients;
+}
+
 interface AuthPayload {
   email: string | null;
   isAuthenticated: boolean;
@@ -18,7 +23,8 @@ export interface UserState {
   isLoggedIn: boolean;
   email: string | null;
   isAuthenticated: boolean;
-  calibration: CalibrationCoefficients;
+  calibrationsBySide: CalibrationsBySide;
+  measurementSide: InjuredSide | null;
   showNormalized: boolean;
   injuredSide: InjuredSide | null;
   hasCompletedOnboarding: boolean;
@@ -35,8 +41,17 @@ const createInitialCalibration = (): CalibrationCoefficients => ({
   calibratedAt: null,
 });
 
+const createInitialCalibrationsBySide = (): CalibrationsBySide => ({
+  LEFT: createInitialCalibration(),
+  RIGHT: createInitialCalibration(),
+});
+
+const getEffectiveMeasurementSide = (state: UserState): InjuredSide =>
+  state.measurementSide ?? state.injuredSide ?? "LEFT";
+
 const resetScopedUserState = (state: UserState) => {
-  state.calibration = createInitialCalibration();
+  state.calibrationsBySide = createInitialCalibrationsBySide();
+  state.measurementSide = null;
   state.showNormalized = false;
   state.injuredSide = null;
   state.hasCompletedOnboarding = false;
@@ -79,7 +94,8 @@ const initialState: UserState = {
   isLoggedIn: false,
   email: null,
   isAuthenticated: false,
-  calibration: createInitialCalibration(),
+  calibrationsBySide: createInitialCalibrationsBySide(),
+  measurementSide: null,
   showNormalized: false,
   injuredSide: null,
   hasCompletedOnboarding: false,
@@ -104,19 +120,35 @@ const userSlice = createSlice({
       state.isAuthenticated = false;
     },
     setCalibration: (state, action: PayloadAction<CalibrationCoefficients>) => {
-      state.calibration = action.payload;
+      state.calibrationsBySide[getEffectiveMeasurementSide(state)] =
+        action.payload;
     },
     resetCalibration: (state) => {
-      state.calibration = createInitialCalibration();
+      state.calibrationsBySide[getEffectiveMeasurementSide(state)] =
+        createInitialCalibration();
       state.showNormalized = false;
     },
     toggleNormalizedMode: (state) => {
-      if (state.calibration.calibratedAt !== null) {
+      if (
+        state.calibrationsBySide[getEffectiveMeasurementSide(state)]
+          .calibratedAt !== null
+      ) {
         state.showNormalized = !state.showNormalized;
       }
     },
     setInjuredSide: (state, action: PayloadAction<InjuredSide>) => {
       state.injuredSide = action.payload;
+      state.measurementSide = action.payload;
+      if (state.calibrationsBySide[action.payload].calibratedAt === null) {
+        state.showNormalized = false;
+      }
+      state.profileOwnerEmail = state.email;
+    },
+    setMeasurementSide: (state, action: PayloadAction<InjuredSide>) => {
+      state.measurementSide = action.payload;
+      if (state.calibrationsBySide[action.payload].calibratedAt === null) {
+        state.showNormalized = false;
+      }
       state.profileOwnerEmail = state.email;
     },
     setInjuryDetails: (state, action: PayloadAction<string>) => {
@@ -142,14 +174,24 @@ export const {
   resetCalibration,
   toggleNormalizedMode,
   setInjuredSide,
+  setMeasurementSide,
   setInjuryDetails,
   setTherapyGoal,
   completeOnboarding,
 } = userSlice.actions;
 
-export const selectCalibration = (state: RootState) => state.user.calibration;
+export const selectMeasurementSide = (state: RootState) =>
+  state.user.measurementSide ?? state.user.injuredSide ?? "LEFT";
+export const selectCalibration = (state: RootState) =>
+  state.user.calibrationsBySide[selectMeasurementSide(state)];
+export const selectCalibrationForSide = (state: RootState, side: InjuredSide) =>
+  state.user.calibrationsBySide[side];
 export const selectIsCalibrated = (state: RootState) =>
-  state.user.calibration.calibratedAt !== null;
+  selectCalibration(state).calibratedAt !== null;
+export const selectHasCalibrationForSide = (
+  state: RootState,
+  side: InjuredSide,
+) => state.user.calibrationsBySide[side].calibratedAt !== null;
 export const selectShowNormalized = (state: RootState) =>
   state.user.showNormalized;
 export const selectInjuredSide = (state: RootState) => state.user.injuredSide;


### PR DESCRIPTION
## Summary
Implements Issue #22 — Bilateral Leg Symmetry Score. Depends on #74 (Clinical Normalization).

## Files Changed
- `services/SymmetryService.ts` — computes per-channel deficit, symmetry score (0-100%), VMO/VL balance, hamstring guarding, and warning flags
- `components/dashboard/SymmetryCard.tsx` — displays symmetry score circle, VMO vs VL balance, hamstring guarding, per-channel breakdown with red warnings
- `app/(tabs)/dashboard.tsx` — mounts SymmetryCard when calibrated and in % MVC mode
- `hooks/useSleeveDevice.ts` — throttled featuresUpdated dispatch to 250ms to prevent infinite re-render loop at 50Hz

## How It Works
- Symmetry Score = 100 - average deficit across all 4 channels
- Deficit per channel = |100% MVC - live normalized %|
- Red warning shown if any channel deficit > 30%
- VMO vs VL balance = |VMO% - VL%| gap
- Hamstring Guarding = Biceps Femoris % (high = over-active)
- Card only appears when calibrated AND in % MVC mode

## Acceptance Criteria
- ✅ Dashboard shows Symmetry Score (0-100%)
- ✅ Comparison based on Normalized % MVC data, not raw voltages
- ✅ Red warning displayed if deficit > 30% for any muscle group
- ✅ VMO Balance and Hamstring Guarding insights shown
- ✅ All 92 tests passing

<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/3f8b3a74-1ccd-4d0b-89b8-250855c27390" />
<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/6734fa64-1f0e-455e-9c94-16cc89641062" />


Closes #22
